### PR TITLE
Add shunt filter to function yourls_keyword_is_taken

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -386,7 +386,7 @@ function yourls_keyword_is_taken( $keyword ) {
 	// Allow plugins to short-circuit the whole function
 	$pre = yourls_apply_filter( 'shunt_keyword_is_taken', false, $keyword );
 	if ( false !== $pre )
-	return $pre;
+		return $pre;
 	
 	global $ydb;
 	$keyword = yourls_sanitize_keyword( $keyword );


### PR DESCRIPTION
I'm working on a plugin to make YOURLS keywords case insensitive. Rather than force all keywords to be lower case, I want users to be able to use upper case letters as well.

For example, the keyword 'MyLink' can be added but no further variations of it ('mylink', 'MYLINK', 'myLink', etc.) will be allowed. To implement this, I would like to create a plugin that short circuits the function 'yourls_keyword_is_taken'. But this would require a shunt filter added to the function itself.
