### PR TITLE
Disable overzealous autoloading

### DIFF
--- a/includes/class-mysql.php
+++ b/includes/class-mysql.php
@@ -619,7 +619,7 @@ $ezsql_mysql_str = array
 */
 
 if ( ! function_exists ('mysql_connect') ) die('<b>Fatal Error:</b> ezSQL_mysql requires mySQL Lib to be compiled and or linked in to the PHP engine');
-if ( ! class_exists ('ezSQLcore') ) die('<b>Fatal Error:</b> ezSQL_mysql requires ezSQLcore (ez_sql_core.php) to be included/loaded before it can be used');
+if ( ! class_exists ('ezSQLcore', false) ) die('<b>Fatal Error:</b> ezSQL_mysql requires ezSQLcore (ez_sql_core.php) to be included/loaded before it can be used');
 
 class ezSQL_mysql extends ezSQLcore
 {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -405,11 +405,11 @@ function yourls_db_connect() {
 		or !defined( 'YOURLS_DB_PASS' )
 		or !defined( 'YOURLS_DB_NAME' )
 		or !defined( 'YOURLS_DB_HOST' )
-		or !class_exists( 'ezSQL_mysql' )
+		or !class_exists( 'ezSQL_mysql', false )
 	) yourls_die ( yourls__( 'DB config missing, or could not find DB class' ), yourls__( 'Fatal error' ), 503 );
 	
 	// Are we standalone or in the WordPress environment?
-	if ( class_exists( 'wpdb' ) ) {
+	if ( class_exists( 'wpdb', false ) ) {
 		$ydb =  new wpdb( YOURLS_DB_USER, YOURLS_DB_PASS, YOURLS_DB_NAME, YOURLS_DB_HOST );
 	} else {
 		$ydb =  new ezSQL_mysql( YOURLS_DB_USER, YOURLS_DB_PASS, YOURLS_DB_NAME, YOURLS_DB_HOST );
@@ -873,11 +873,11 @@ function yourls_geo_countrycode_to_countryname( $code ) {
 		return $country;
 
 	// Load the Geo class if not already done
-	if( !class_exists( 'GeoIP' ) ) {
+	if( !class_exists( 'GeoIP', false ) ) {
 		$temp = yourls_geo_ip_to_countrycode( '127.0.0.1' );
 	}
 	
-	if( class_exists( 'GeoIP' ) ) {
+	if( class_exists( 'GeoIP', false ) ) {
 		$geo  = new GeoIP;
 		$id   = $geo->GEOIP_COUNTRY_CODE_TO_NUMBER[ $code ];
 		$long = $geo->GEOIP_COUNTRY_NAMES[ $id ];

--- a/includes/geo/geoip.inc
+++ b/includes/geo/geoip.inc
@@ -53,7 +53,7 @@ define("GEOIP_DIALUP_SPEED", 1);
 define("GEOIP_CABLEDSL_SPEED", 2);
 define("GEOIP_CORPORATE_SPEED", 3);
 
-if( !class_exists('GeoIP') ) {
+if( !class_exists('GeoIP', false) ) {
 class GeoIP {
     var $flags;
     var $filehandle;

--- a/includes/pomo/entry.php
+++ b/includes/pomo/entry.php
@@ -7,7 +7,7 @@
  * @subpackage entry
  */
 
-if ( !class_exists( 'Translation_Entry' ) ):
+if ( !class_exists( 'Translation_Entry', false ) ):
 /**
  * Translation_Entry class encapsulates a translatable string
  */

--- a/includes/pomo/mo.php
+++ b/includes/pomo/mo.php
@@ -10,7 +10,7 @@
 require_once dirname(__FILE__) . '/translations.php';
 require_once dirname(__FILE__) . '/streams.php';
 
-if ( !class_exists( 'MO' ) ):
+if ( !class_exists( 'MO', false ) ):
 class MO extends Gettext_Translations {
 
 	var $_nplurals = 2;

--- a/includes/pomo/po.php
+++ b/includes/pomo/po.php
@@ -16,7 +16,7 @@ ini_set('auto_detect_line_endings', 1);
 /**
  * Routines for working with PO files
  */
-if ( !class_exists( 'PO' ) ):
+if ( !class_exists( 'PO', false ) ):
 class PO extends Gettext_Translations {
 
 	var $comments_before_headers = '';

--- a/includes/pomo/streams.php
+++ b/includes/pomo/streams.php
@@ -8,7 +8,7 @@
  * @subpackage streams
  */
 
-if ( !class_exists( 'POMO_Reader' ) ):
+if ( !class_exists( 'POMO_Reader', false ) ):
 class POMO_Reader {
 
 	var $endian = 'little';
@@ -102,7 +102,7 @@ class POMO_Reader {
 }
 endif;
 
-if ( !class_exists( 'POMO_FileReader' ) ):
+if ( !class_exists( 'POMO_FileReader', false ) ):
 class POMO_FileReader extends POMO_Reader {
 	function POMO_FileReader($filename) {
 		parent::POMO_Reader();
@@ -142,7 +142,7 @@ class POMO_FileReader extends POMO_Reader {
 }
 endif;
 
-if ( !class_exists( 'POMO_StringReader' ) ):
+if ( !class_exists( 'POMO_StringReader', false ) ):
 /**
  * Provides file-like methods for manipulating a string instead
  * of a physical file.
@@ -182,7 +182,7 @@ class POMO_StringReader extends POMO_Reader {
 }
 endif;
 
-if ( !class_exists( 'POMO_CachedFileReader' ) ):
+if ( !class_exists( 'POMO_CachedFileReader', false ) ):
 /**
  * Reads the contents of the file in the beginning.
  */
@@ -197,7 +197,7 @@ class POMO_CachedFileReader extends POMO_StringReader {
 }
 endif;
 
-if ( !class_exists( 'POMO_CachedIntFileReader' ) ):
+if ( !class_exists( 'POMO_CachedIntFileReader', false ) ):
 /**
  * Reads the contents of the file in the beginning.
  */

--- a/includes/pomo/translations.php
+++ b/includes/pomo/translations.php
@@ -9,7 +9,7 @@
 
 require_once dirname(__FILE__) . '/entry.php';
 
-if ( !class_exists( 'Translations' ) ):
+if ( !class_exists( 'Translations', false ) ):
 class Translations {
 	var $entries = array();
 	var $headers = array();
@@ -227,7 +227,7 @@ class Gettext_Translations extends Translations {
 }
 endif;
 
-if ( !class_exists( 'NOOP_Translations' ) ):
+if ( !class_exists( 'NOOP_Translations', false ) ):
 /**
  * Provides the same interface as Translations, but doesn't do anything
  */


### PR DESCRIPTION
Due to how class_exists() works in PHP, if an auto-loader has been specified, calling this function will trigger the auto-loader and it will try to load the class in question (see http://www.php.net/manual/en/function.class-exists.php )

This is very annoying behavior when you have more than one code-base interacting with each other and one side defines an auto-loader.
