### PR TITLE
Decode URL before encoding it to avoid double encoding

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -180,6 +180,7 @@ function yourls_add_new_link( $url, $keyword = '', $title = '' ) {
 	if ( false !== $pre )
 		return $pre;
 		
+	$url = urldecode( $url ); //make sure url is decoded before encoding to avoid double encoding
 	$url = yourls_encodeURI( $url );
 	$url = yourls_escape( yourls_sanitize_url( $url ) );
 	if ( !$url || $url == 'http://' || $url == 'https://' ) {


### PR DESCRIPTION
Add urldecode to function yourls_add_new_link.  This is to prevent encoding an already encoded url.

I believe this fixes Issue #1303.
