### PR TITLE
BugFix - Encoding URL

### DIFF
--- a/includes/functions-formatting.php
+++ b/includes/functions-formatting.php
@@ -541,7 +541,9 @@ function yourls_esc_textarea( $text ) {
 * @param $url
 * @return string
 */
-function yourls_encodeURI( $url ) {
+function yourls_encodeURI( $url, $decoding = true ) {
+	if ( $decoding )
+		$url = rawurldecode( $url );
 	return strtr( rawurlencode( $url ), array (
 		'%3B' => ';', '%2C' => ',', '%2F' => '/', '%3F' => '?', '%3A' => ':', '%40' => '@',
 		'%26' => '&', '%3D' => '=', '%2B' => '+', '%24' => '$', '%21' => '!', '%2A' => '*',


### PR DESCRIPTION
Be sure to have a decoded URL, to prevent encoding an already encoded URL.
Add an opt-out option to bypass decoding.
