### PR TITLE
Basic autocron functionality

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1183,6 +1183,93 @@ function yourls_maybe_require_auth() {
 }
 
 /**
+ * This function uses fsockopen() to run yourls-cron.php which is where the
+ * body of all desired cron jobs are run. This happens asynchronously so that
+ * URL redirection occurs without any delay for the user.
+ *
+ * The HTTP call is only executed once enough time has elapsed since the last
+ * cron job was run.
+ *
+ * TODO: Use a real HTTP library, like WordPress.
+ */
+function yourls_maybe_cron() {
+	/**
+	 * This function is called every time YOURLS is loaded, and autocron
+	 * needs to load YOURLS so it can use the plugin architecture.
+	 *
+	 * If we got here from autocron, abort immediately.
+	 */
+	if ( defined( 'YOURLS_IN_CRON' ) ) {
+		return;
+	}
+	
+	if ( yourls_shouldwe_cron() ) {
+		$errno   = 0;
+		$errstr  = '';
+		$timeout = 0.01;
+		
+		$url       = YOURLS_SITE . '/yourls-cron.php';
+		$url_parts = parse_url( $url );
+		if ( !isset( $url_parts['port'] ) ) {
+			$url_parts['port'] = ( $url_parts['scheme']==='https' ? 443 : 80 );
+		}
+		$conn_path = $url_parts['path'];
+		$conn_port = $url_parts['port'];
+		$real_host = $url_parts['host'];
+		
+		if ( preg_match( '/^[\d\.]*$/', $real_host ) ) {
+			// If ServerName is an IP address, that's fine.
+			$conn_host = $real_host;
+		} else {
+			// Confirm that the hostname is resolvable
+			$resolved = gethostbyname( $real_host );
+			if ( $resolved === $real_host ) {
+				error_log( "DNS resolution failed for host $real_host" );
+				return;
+			} else {
+				$conn_host = $resolved;
+			}
+		}
+		
+		$request   = "GET $conn_path HTTP/1.1\r\n";
+		$headers   = array();
+		$headers[] = 'User-Agent: YOURLS/' . YOURLS_VERSION;
+		$headers[] = 'Host: ' . $real_host; // TODO: Is this safe?
+		$request  .= implode("\r\n", $headers);
+		$request  .= "\r\n\r\n";
+		
+		$fp = fsockopen( $conn_host, $conn_port, $errno, $errstr, $timeout );
+		if ( false === $fp ) {
+			error_log( $errstr );
+			die( "fsockopen() returned an error with host=$conn_host" );
+		}
+		
+		fwrite( $fp, $request );
+		fclose( $fp );
+	}
+}
+
+/**
+ * Returns true if elapsed time since last cron job is longer than
+ * threshold for running cron jobs.
+ */
+function yourls_shouldwe_cron() {
+	$lastCronTime      = intval( yourls_get_option( 'yourls_last_cron' ));
+	$timeSinceLastCron = time() - $lastCronTime;
+	$shouldCron        = ( $timeSinceLastCron > yourls_cron_interval() );
+	
+	return $shouldCron;
+}
+
+/**
+ * Define the minimum number of seconds between cron jobs.
+ * TODO: Make this a configurable user option
+ */
+function yourls_cron_interval() {
+	return 60;
+}
+
+/**
  * Allow several short URLs for the same long URL ?
  *
  */

--- a/includes/load-yourls.php
+++ b/includes/load-yourls.php
@@ -177,6 +177,9 @@ if ( !yourls_is_upgrading() && !yourls_is_installing() ) {
 yourls_load_plugins();
 yourls_do_action( 'plugins_loaded' );
 
+// Fire cron action during page load, if enough time has elapsed since last cron
+yourls_maybe_cron();
+
 if( yourls_is_admin() )
 	yourls_do_action( 'admin_init' );
 

--- a/yourls-cron.php
+++ b/yourls-cron.php
@@ -1,0 +1,35 @@
+<?php
+define( 'YOURLS_CURRENT_PAGE', 'cron' );
+define( 'YOURLS_IN_CRON', true );
+
+/**
+ * There are two possible entry points to this script.
+ * 1. The PHP command-line, as run by a system cron job.
+ * 2. Called asynchronously over HTTP via fsockopen() in yourls_maybe_cron().
+ *
+ * This script will update the timestamp of the last cron job, then
+ * fire off an action called "cron" with the YOURLS plugin API.
+ *
+ * TODO: Maybe change the max execution time for this script?
+ */
+ 
+/**
+ * Allow the script to keep running, even if the client disconnects.
+ * This is key to making async HTTP calls work correctly.
+ */
+ignore_user_abort(true);
+
+require_once( dirname( __FILE__ ) . '/includes/load-yourls.php' );
+
+// Check elapsed time since last cronjob so we don't execute too often
+if ( yourls_shouldwe_cron() ) {
+	/**
+	 * Immediate update the last_cron timestamp. Why here?
+	 *
+	 * 1. If we updated the timestamp AFTER firing the action, that could allow
+	 *    multiple cron tasks to spawn in quick succession and run in parallel.
+	 * 2. It needs to be here so that system cron jobs also update the timestamp.
+	 */
+	yourls_update_option( 'yourls_last_cron', time() );
+	yourls_do_action( 'cron' );
+}


### PR DESCRIPTION
This branch adds partial "auto cron" support (issue #1233) to YOURLS in the form of a pluggable action called `cron`.

Every time a page is loaded, check to see if the last `cron` run happened more than 60 seconds ago. If yes, then generate a new HTTP request for `yourls-cron.php` and send it asynchronously via `fsockopen()`. Or alternately, `yourls-cron.php` can be executed by a system cron job via the PHP command line interpreter.

A plugin with complicated scheduling requirements may opt to hook this cron action directly. 

**What's next**
Allow simple plugins to request a periodic action like this.

```
yourls_schedule_action( YOURLS_HOURLY, 'myplugin_cleanup' );
```
