### PR TITLE
Defer shunt_add_new_link filter until after url is sanitized

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -183,9 +183,11 @@ function yourls_url_exists( $url ) {
  *
  */
 function yourls_add_new_link( $url, $keyword = '', $title = '' ) {
-	// Calling yourls_sanitize_url BEFORE shunt_add_new_link fixes issues
-	// like missing scheme, that would otherwise prevent parse_url from
-	// working. Otherwise, plugins would have to call sanitize_url.
+	// Allow plugins to short-circuit the whole function
+	$pre = yourls_apply_filter( 'shunt_add_new_link', false, $url, $keyword, $title );
+	if ( false !== $pre )
+		return $pre;
+
 	$url = yourls_encodeURI( $url );
 	$url = yourls_escape( yourls_sanitize_url( $url ) );
 	if ( !$url || $url == 'http://' || $url == 'https://' ) {
@@ -195,11 +197,6 @@ function yourls_add_new_link( $url, $keyword = '', $title = '' ) {
 		$return['errorCode'] = '400';
 		return yourls_apply_filter( 'add_new_link_fail_nourl', $return, $url, $keyword, $title );
 	}
-	
-	// Allow plugins to short-circuit the whole function
-	$pre = yourls_apply_filter( 'shunt_add_new_link', false, $url, $keyword, $title );
-	if ( false !== $pre )
-		return $pre;
 		
 	// Prevent DB flood
 	$ip = yourls_get_IP();
@@ -215,6 +212,10 @@ function yourls_add_new_link( $url, $keyword = '', $title = '' ) {
 			return yourls_apply_filter( 'add_new_link_fail_noloop', $return, $url, $keyword, $title );
 		}
 	}
+
+	$proceed = yourls_apply_filter( 'should_add_new_link', true, $url, $keyword, $title );
+	if ( true !== $proceed )
+		return $proceed;
 
 	yourls_do_action( 'pre_add_new_link', $url, $keyword, $title );
 	


### PR DESCRIPTION
This isn't strictly a bug in YOURLS, but as a plugin developer I hope you will consider this change.

The `yourls_add_new_link` function calls the `shunt_add_new_link` filter before sanitizing the `$url` parameter, so it's possible for the `http://` scheme to be missing if the user left it out. In my [domainlimit](https://github.com/nicwaller/yourls-domainlimit-plugin/blob/master/domainlimit/plugin.php) plugin, I try to use PHP's `parse_url` function which expects $url to be RFC-compliant, and that fails if the URL is missing an `http://` scheme.

So there are two ways to fix this:
- I could call `yourls_sanitize_url` in my plugin to ensure that a scheme is present, or
- You could defer the shunt filter until after the URL has been sanitized

I think that deferring the call to shunt is cleaner because it avoids repetitive calls to the same function. I look forward to your comments. 
