### PR TITLE
Include title parameter in the API example

### DIFF
--- a/sample-remote-api-call.txt
+++ b/sample-remote-api-call.txt
@@ -31,6 +31,7 @@ curl_setopt($ch, CURLOPT_POST, 1);              // This is a POST request
 curl_setopt($ch, CURLOPT_POSTFIELDS, array(     // Data to POST
 		'url'      => $url,
 		'keyword'  => $keyword,
+		'title'    => $keyword, // If omitted, Yourls will lookup TITLE with an HTTP request
 		'format'   => $format,
 		'action'   => 'shorturl',
 		'username' => $username,


### PR DESCRIPTION
Title should be included as one of the post fields in the example so that people are aware of it, and also aware that NOT including it incurs a significant (10x) performance penalty.

See related issue https://github.com/YOURLS/YOURLS/issues/1454
