### PR TITLE
Fixed bug which displayed direct count instead of redirect count

### DIFF
--- a/yourls-infos.php
+++ b/yourls-infos.php
@@ -518,7 +518,7 @@ yourls_html_menu();
 					yourls_stats_pie( array( yourls__( 'Direct' ) => $direct, yourls__( 'Referrers' ) => $notdirect ), 5, '440x220', 'stat_tab_source_direct' );
 					?>
 					<p><?php yourls_e( 'Direct traffic:' ); echo ' ' . sprintf( yourls_n( '<strong>%s</strong> hit', '<strong>%s</strong> hits', $direct ), $direct ); ?> </p>
-					<p><?php yourls_e( 'Referrer traffic:' ); echo ' ' . sprintf( yourls_n( '<strong>%s</strong> hit', '<strong>%s</strong> hits', $notdirect ), $direct ); ?> </p>
+					<p><?php yourls_e( 'Referrer traffic:' ); echo ' ' . sprintf( yourls_n( '<strong>%s</strong> hit', '<strong>%s</strong> hits', $notdirect ), $notdirect ); ?> </p>
 
 				</td>
 			</tr>


### PR DESCRIPTION
The pie graph shows both redirect and direct statistics, but the count only reflects the direct count in the summary.

Before:
![screen shot 2013-07-15 at 5 50 29 pm](https://f.cloud.github.com/assets/965298/801972/e5f3b006-edb1-11e2-9145-66ef3a66fe5a.png)

After:
![screen shot 2013-07-15 at 5 50 49 pm](https://f.cloud.github.com/assets/965298/801970/dcdcfcca-edb1-11e2-959f-9ce890b3fc58.png)
