### PR TITLE
Add Delete to API

### DIFF
--- a/includes/functions-api.php
+++ b/includes/functions-api.php
@@ -39,7 +39,6 @@ function yourls_api_action_delete() {
 			'errorCode' => 404,
 		);
 	}
-	unset( $return['html'] ); // in API mode, no need for our internal HTML output
 	return yourls_apply_filter( 'api_result_delete', $return );
 }
 

--- a/yourls-api.php
+++ b/yourls-api.php
@@ -18,7 +18,7 @@ yourls_do_action( 'api', $action );
 // Define standard API actions
 $api_actions = array(
 	'shorturl'  => 'yourls_api_action_shorturl',
-	'delete'	=> 'yourls_api_action_delete',
+	'delete'    => 'yourls_api_action_delete',
 	'stats'     => 'yourls_api_action_stats',
 	'db-stats'  => 'yourls_api_action_db_stats',
 	'url-stats' => 'yourls_api_action_url_stats',


### PR DESCRIPTION
Adds delete functionality to the API. Always requires authentication to prevent users on public servers from deleting links created by others.
