### PR TITLE
get rid of ugly parsing of request (for punycode)

### DIFF
--- a/includes/functions-install.php
+++ b/includes/functions-install.php
@@ -113,7 +113,7 @@ function yourls_create_htaccess() {
 			'RewriteBase '.$path.'/',
 			'RewriteCond %{REQUEST_FILENAME} !-f',
 			'RewriteCond %{REQUEST_FILENAME} !-d',
-			'RewriteRule ^.*$ '.$path.'/yourls-loader.php [L]',
+			'RewriteRule ^.*$ '.$path.'/yourls-loader.php?short=$1 [QSA,L]',
 			'</IfModule>',
 		);
 	

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1816,15 +1816,7 @@ function yourls_get_request() {
 	if( $request !== null )
 		return $request;
 	
-	// Ignore protocol & www. prefix
-	$root = str_replace( array( 'https://', 'http://', 'https://www.', 'http://www.' ), '', YOURLS_SITE );
-	// Case insensitive comparison of the YOURLS root to match both http://Sho.rt/blah and http://sho.rt/blah
-	$request = preg_replace( "!$root/!i", '', $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], 1 );
-
-	// Unless request looks like a full URL (ie request is a simple keyword) strip query string
-	if( !preg_match( "@^[a-zA-Z]+://.+@", $request ) ) {
-		$request = current( explode( '?', $request ) );
-	}
+        $request = $_GET['short'];
 	
 	return yourls_apply_filter( 'get_request', $request );
 }


### PR DESCRIPTION
Hey,

I was trying to install YOURLS to `http://µ.mydomain.invalid`. Now, this wouldn't work, because YOURLS tries to prepend YOURLS_SITE to the request uri, then cut it away afterwards. I don't think this is a good idea anyway.

Now I could fix it with setting YOURLS_SITE to `http://xn--xxa.mydomain.invalid`. But then, shortend links in the admin interface will have this ugly domain.

The best solution would be, in my opinion, not to have the request URI just pass "as it is", but as a value of a named parameter. This way there is no need to mess around with `$_SERVER['REQUEST_URI'].`

This method has some advantages:
1.) punycode will finally work!
2.) No messy handling of protocols, et al.
3.) It won't break anything else (nothing that I know of, needs testing).

Please, kindly review this patch. I'm very willing to modify it, if needed.
Also, don't forget to update [.htacces documentation](https://github.com/YOURLS/YOURLS/wiki/.htaccess), if you pull.
## 

Ben

PS: are you sure, $request should be static? IMO the function should be, but not the variable. If two parallel requests came to call the same function at the very same time, one of them might get redirect to the site of the other request.
