### PR TITLE
Put 5.2 back in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.3
   - 5.4
   - 5.5
-  - hhvm
 
 env:
   - DB=mysql


### PR DESCRIPTION
Because it _has_ to work.

Unless some of us actually tests locally on their machine using 5.2, we should make sure Travis tests are checked against 5.2 and passing
