### PR TITLE
Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "yourls/yourls",
+    "description": "Your Own URL Shortener",
+    "keywords": [
+        "shortener",
+        "short url",
+        "url",
+        "bitly"
+    ],
+    "homepage": "http://yourls.org",
+    "type": "project",
+    "license": "MIT",
+    "authors" : [
+        {
+            "name": "Ozh Richard",
+            "homepage": "http://ozh.org",
+            "role": "Developer"
+        },
+        {
+            "name": "Leo Colombaro",
+            "homepage": "http://colombaro.fr",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.0",
+        "pomo/pomo": "*",
+        "rmccue/requests": "*",
+        "monolog/monolog": "*",
+        "jwage/purl": "*",
+        "nesbot/carbon": "*",
+        "fzaninotto/streamer": "*"
+    },
+    "require-dev": {
+        "filp/whoops": "1.*"
+    },
+    "suggest": {
+        "lib-curl": "Allow API external transactions",
+        "lib-openssl": "Allow HTTPS connexions"
+    },
+    "config": {
+        "vendor-dir": "includes/vendor"
+    }
+}


### PR DESCRIPTION
_[Composer](http://getcomposer.org/) is a tool for dependency management in PHP. It allows you to declare the dependent libraries your project needs and it will install them in your project for you._
## Why we should use it
- Simplify #1583 task
- Re simplify the life
- Improve flexibility
- Better version manipulation
- No more big update (*)
- Clean repo (*)
- Only **one** file PHP-required to include **all** lib 
- Only one other file to have composer ok
- Easy Namespaces
- ...
- Actually all reasons for why other languages have already equivalent
## Why we should _not_ use it
- Need Composer installation
- Not ready-to-use (*)
- ... (?)
## Why we finely should use it
- Installation is super easy, even on Windows
- Build nightlies is super easy (*)
- GitHub release have the ability to attach binaries (*)

**(*) All of these points can be deleted if we use Composer AND keep libs files in the repo.**
