### PR TITLE
Fix broken image tag

### DIFF
--- a/yourls-infos.php
+++ b/yourls-infos.php
@@ -208,7 +208,7 @@ yourls_html_menu();
 
 <h2 id="informations"><?php echo yourls_esc_html( $title ); ?></h2>
 
-<h3><span class="label"><?php yourls_e( 'Short URL'); ?>:</span> <img src="<?php yourls_favicon() ?>"/>
+<h3><span class="label"><?php yourls_e( 'Short URL'); ?>:</span> <img src="<?php echo yourls_favicon() ?>"/>
 <?php if( $aggregate ) {
 	$i = 0;
 	foreach( $keyword_list as $k ) {


### PR DESCRIPTION
There's a missing `echo` in `yourls-infos.php` that causes the favicon not to be rendered next to the short URL.  This patch fixes that.

Happy hacking.  :)
