### PR TITLE
Adding a line break for URLs that are very long.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -328,3 +328,6 @@ a.bookmarklet:hover {
 tr.plugin.active a{ font-weight:bolder;}
 body.desktop tr.plugin td.plugin_desc small{ visibility:hidden;}
 tr:hover.plugin td.plugin_desc small{ visibility:visible;}
+#wrap h2{
+    word-break: break-all;
+}


### PR DESCRIPTION
We had a couple of URLs that were extremely long (triggering report generation), and they overflowed off the page.

This change will wrap that text into the surrounding div.  I didn't want to make it global (inside the #wrap div) because it affected other elements.
