### PR TITLE
Adding a line break for URLs that are very long.

### DIFF
--- a/css/infos.css
+++ b/css/infos.css
@@ -111,3 +111,6 @@ ul.no_bullet li {
 	min-width:100px;
 	display:inline-block;
 }
+h2#informations{
+	word-break: break-all;
+}


### PR DESCRIPTION
This change adds the appropriate line-break to the infos.css as suggested by @ozh

This only targets the url in the h2#informations element.
