### PR TITLE
Fixes editing of entries with '%' and '"' characters in title or URL.

### DIFF
--- a/includes/functions-formatting.php
+++ b/includes/functions-formatting.php
@@ -554,6 +554,17 @@ function yourls_esc_textarea( $text ) {
 	return yourls_apply_filter( 'esc_textarea', $safe_text, $text );
 }
 
+/**
+ * Escaping for input form fields.
+ *
+ * @param string $text
+ * @return string
+ */
+function yourls_esc_inputfield( $text ) {
+	$safe_text = str_replace( '%', '&#37;', $text );	// remove '%' for sprintf()
+	$safe_text = str_replace( '"', '&quot;', $safe_text );	// remove '"' for use in <input value="...">
+	return $safe_text;
+}
 
 /**
 * PHP emulation of JS's encodeURI

--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -449,8 +449,8 @@ function yourls_table_edit_row( $keyword ) {
 	$url = yourls_get_keyword_longurl( $keyword );
 	
 	$title = htmlspecialchars( yourls_get_keyword_title( $keyword ) );
-	$safe_url = yourls_esc_attr( $url );
-	$safe_title = yourls_esc_attr( $title );
+	$safe_url = yourls_esc_inputfield( rawurldecode( yourls_esc_attr( $url ) ) );
+	$safe_title = yourls_esc_inputfield( yourls_esc_attr( $title ) );
 	$www = yourls_link();
 	
 	$nonce = yourls_create_nonce( 'edit-save_'.$id );
@@ -459,8 +459,7 @@ function yourls_table_edit_row( $keyword ) {
 		$return = <<<RETURN
 <tr id="edit-$id" class="edit-row"><td colspan="5" class="edit-row"><strong>%s</strong>:<input type="text" id="edit-url-$id" name="edit-url-$id" value="$safe_url" class="text" size="70" /><br/><strong>%s</strong>: $www<input type="text" id="edit-keyword-$id" name="edit-keyword-$id" value="$keyword" class="text" size="10" /><br/><strong>%s</strong>: <input type="text" id="edit-title-$id" name="edit-title-$id" value="$safe_title" class="text" size="60" /></td><td colspan="1"><input type="button" id="edit-submit-$id" name="edit-submit-$id" value="%s" title="%s" class="button" onclick="edit_link_save('$id');" />&nbsp;<input type="button" id="edit-close-$id" name="edit-close-$id" value="%s" title="%s" class="button" onclick="edit_link_hide('$id');" /><input type="hidden" id="old_keyword_$id" value="$keyword"/><input type="hidden" id="nonce_$id" value="$nonce"/></td></tr>
 RETURN;
-        $return = preg_replace( '/%([^s])/', '%%$1', $return ); // make sprintf() safe: '%' -> '%%'
-		$return = sprintf( rawurldecode( $return ), yourls__( 'Long URL' ), yourls__( 'Short URL' ), yourls__( 'Title' ), yourls__( 'Save' ), yourls__( 'Save new values' ), yourls__( 'Cancel' ), yourls__( 'Cancel editing' ) );
+		$return = sprintf( $return, yourls__( 'Long URL' ), yourls__( 'Short URL' ), yourls__( 'Title' ), yourls__( 'Save' ), yourls__( 'Save new values' ), yourls__( 'Cancel' ), yourls__( 'Cancel editing' ) );
 	} else {
 		$return = '<tr class="edit-row notfound"><td colspan="6" class="edit-row notfound">' . yourls__( 'Error, URL not found' ) . '</td></tr>';
 	}


### PR DESCRIPTION
Adds new function `yourls_esc_inputfield()` in file `includes/functions-html.php`:
Filter  `"` (double quotation mark) into `&quot;` for glueing strings into HTML `<input …>` form fields.
Percent signs `%` are converted to HTML entity `&#37;` to prevent `sprintf()` choking from too many `%`.
Please note: The function expects urldecoded input, so `$url` has to be piped through `rawurldecode()` first. 

Removed doubling of percent signs as it should not be required anymore.
