### PR TITLE
Updated readme.html to point to nginx config in wiki. Removed outdated links.

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -595,7 +595,7 @@ echo $data->longurl;</tt></pre>
 				<li>A server with <strong>mod_rewrite</strong> enabled</li>
 				<li>At least <strong>PHP 5.2</strong></li>
 				<li>At least <strong>MYSQL 4.1</strong></li>
-				<li><em>Note</em>: YOURLS can also run on <a href="http://www.packetcollision.com/2012/01/27/yourls-and-nginx-an-updated-config/">Nginx</a> and <a href="http://www.ututech.com/2010/10/configuring-yourls-to-work-with-cherokee-web-server/">Cherokee</a></li>
+				<li><em>Note</em>: YOURLS can also run on <a href="https://github.com/YOURLS/YOURLS/wiki/Nginx-configuration">Nginx</a> and <a href="http://www.ututech.com/2010/10/configuring-yourls-to-work-with-cherokee-web-server/">Cherokee</a></li>
 			</ol>
 
 			<h3 id="recommendation">Server recommendations</h3>
@@ -685,9 +685,6 @@ echo $data->longurl;</tt></pre>
 				<li><a href="http://xib.me/">http://xib.me/</a></br/>
 				A nicely styled YOURLS public interface</li>
 				
-				<li><a href="http://rml.me/">http://rml.me/</a><br/>
-				A personal URL shortener front page showing new links and most clicked links</li>
-				
 				<li><a href="http://vt802.us/">http://vt802.us/</a><br/>
 				Defined as "The World's First Vermont-centric URL Shortener"</li>
 				
@@ -739,9 +736,6 @@ echo $data->longurl;</tt></pre>
 				
 				<li id="tweetbot"><a href="http://2fatdads.com/2012/02/how-to-make-yourls-org-work-in-tweetbot/">Tweetbot</a><br/>
 				Make Tweetbot run with YOURLS</li>
-				
-				<li id="seesmic"><a href="http://christophe.rousee.fr/plugin-yourls-pour-seesmic-desktop-2">Seesmic</a><br/>
-				Use YOURLS with Seesmic</li>
 				
 				<li id="twitterfeed"><a href="http://blog.yourls.org/2011/09/how-to-use-twitterfeed-with-your-custom-yourls-url-shortener/">Twitterfeed</a><br/>
 				Use Twitterfeed with YOURLS</li>


### PR DESCRIPTION
The Yourls wiki has [a page](https://github.com/YOURLS/YOURLS/wiki/Nginx-configuration) about configuring nginx: The file `readme.html` should point to it. (Or maybe, add short link http://yourls.org/nginx pointing to the wiki?) 

The domain `http://rml.me` is currently for sale and should be removed from the server recommendation list.

The page describing the Seesmic plugin seems not available anymore.
