### PR TITLE
Rewrite regex in getTabs() in readme.html to work on IE 11. Fixes #1797

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -815,10 +815,10 @@ echo $data->longurl;</tt></pre>
 	// Dynamically get tabs
 	function getTabs() {
 		var d = document.getElementById('Tabs');
-		var matches = d.innerHTML.match(/<li id="(.+?)Tab"/g);
+		var matches = d.innerHTML.match(/<li.* id="(.+?)Tab"/g);
 		var tabs = []
 		for (i in matches) {
-		  tabs[i]= matches[i].replace('<li id="','').replace('Tab"', '');
+		  tabs[i]= matches[i].replace(/<li.* id="/,'').replace('Tab"', '');
 		}
 		tabs = tabs.reverse();
 		return (tabs)


### PR DESCRIPTION
This fixes the navigation menu bar of `readme.html` on Internet Explorer 11 (and hopefully down to IE 9). 

Tested on these fine browsers:
- Google Chrome 38.0.2125.111 :heavy_check_mark:
- Iceweasel 31.2.0 :heavy_check_mark:
- Internet Explorer 8.0 (Windows XP SP3) :x:
- Internet Explorer 11.0 (Windows 7 SP1) :heavy_check_mark:
- Internet Explorer 11.0 (Windows 8.1) :heavy_check_mark:
- midori 0.5.8 :heavy_check_mark:
- Mozilla Firefox 33.0 :heavy_check_mark:
- Opera 12.16 :heavy_check_mark:
