### PR TITLE
Update functions-l10n.php

### DIFF
--- a/includes/functions-l10n.php
+++ b/includes/functions-l10n.php
@@ -1045,7 +1045,7 @@ class YOURLS_Locale_Formats {
  */
 function yourls_load_custom_textdomain( $domain, $path ) {
 	$locale = yourls_apply_filter( 'load_custom_textdomain', yourls_get_locale(), $domain );
-	$mofile = trim( $path, '/' ) . '/'. $domain . '-' . $locale . '.mo';
+	$mofile = rtrim( $path, '/' ) . '/'. $domain . '-' . $locale . '.mo';
 
 	return yourls_load_textdomain( $domain, $mofile );
 }


### PR DESCRIPTION
´yourls_load_custom_textdomain´ can't read *.mo files when ´$path´ is an absolute path on the server and the leading slash is removed. (´trim´ removes on both ends)