### PR TITLE
Update insert.js

### DIFF
--- a/js/insert.js
+++ b/js/insert.js
@@ -133,7 +133,7 @@ function edit_link_hide(id) {
 // Save edition of a link
 function edit_link_save(id) {
 	add_loading("#edit-close-" + id);
-	var newurl = encodeURI( $("#edit-url-" + id).val() );
+	var newurl = $("#edit-url-" + id).val();
 	var newkeyword = $("#edit-keyword-" + id).val();
 	var title = $("#edit-title-" + id).val();
 	var keyword = $('#old_keyword_'+id).val();


### PR DESCRIPTION
Altered the function edit_link_save, Links containing encoded content like % => %25 will be further encoded to %2525 which breaks the link. As the add_link() did not contain a encoding for the url it seems save to remove it in the edit_link_save as well.