### PR TITLE
added index page

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,0 +1,46 @@
+<?php
+require_once( dirname(__FILE__).'/includes/load-yourls.php' );
+
+yourls_html_head();
+yourls_html_logo();
+?>
+	<ul id="admin_menu">
+		<li>Go to the <a href="<?php echo yourls_admin_url('index.php') ?>">Admin Interface</a></li>
+	</ul>
+	<div class="sub_wrap">
+	
+		<h2>Resolve URL</h2>
+		<div>
+			<form id="resolve_url_form" action="" method="get">
+				<div><strong>Enter Short URL</strong>:<input type="text" id="short-url" name="short-url" value="" class="text" size="8" />
+				<input type="button" id="resolve-button" name="resolve-button" value="Resolve" class="button" onclick="resolve();" /></div>
+			</form>
+		</div>
+		
+		
+	</div>
+	
+	<div>
+		<h2>Add new URL</h2>
+		<div>
+			<form id="new_url_form" action="" method="get">
+				<div><strong>Enter the URL</strong>:<input type="text" id="add-url" name="url" value="" class="text" size="80" />
+				Optional: <strong>Custom short URL</strong>:<input type="text" id="add-keyword" name="keyword" value="" class="text" size="8" />
+				<input type="button" id="add-button" name="add-button" value="Shorten The URL" class="button" onclick="add_forward();" /></div>
+			</form>
+		</div>
+	</div>
+	<script type="text/javascript">
+	var base_url = "<?php yourls_site_url() ?>";
+	function resolve(){
+		var keyword = document.getElementById("short-url").value;
+		window.location = base_url+"/"+keyword;
+	}
+	function add_forward(){
+		var keyword = document.getElementById("add-keyword").value;
+		var url = document.getElementById("add-url").value;
+		window.location = base_url+"/admin/index.php?u="+encodeURIComponent(url)+"&k="+keyword;
+	}
+	</script>
+
+<?php yourls_html_footer(); ?>


### PR DESCRIPTION
I added a index.php page to quickly create and resolve short URLs. It avoids the 403/404 error when the base URL of yourls is called. 
It renders two different forms, one for resolving a short url, and one for creating a new one (similar to the form on the admin page, but when the submit button is pressed, it forwards the content just like the bookmarklet does).
I create this page, just to "scratch my own itch" and maybe this is useful to others as well. However I can understand that some people might see no additional benefit from such a page (after all, all it does, copy the functionality of the bookmarklet and provide a text field for something you can just as well write in the URL bar of your browser). But the way I see it, this can not be done with an plugin, since the call for the base URL would never reach yourls (please correct me, if I am mistaken about this).
Alternatively this page could be renamed, and users would have to change it's name to index.php to enable it. Or it could just be documented in the wiki as is the case with [RSS.php](https://github.com/YOURLS/YOURLS/wiki/RSS.php). I will leave this decision to you.
Cheers, Frog23