### PR TITLE
Smarter domain convention in examples and source

### DIFF
--- a/includes/functions-formatting.php
+++ b/includes/functions-formatting.php
@@ -51,7 +51,7 @@ function yourls_string2htmlid( $string ) {
 }
 
 /**
- * Make sure a link keyword (ie "1fv" as in "site.com/1fv") is valid.
+ * Make sure a link keyword (ie "1fv" as in "http://sho.rt/1fv") is valid.
  *
  */
 function yourls_sanitize_string( $string ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1885,7 +1885,7 @@ function yourls_is_mobile_device() {
 }
 
 /**
- * Get request in YOURLS base (eg in 'http://site.com/yourls/abcd' get 'abdc')
+ * Get request in YOURLS base (eg in 'http://sho.rt/yourls/abcd' get 'abdc')
  *
  */
 function yourls_get_request() {

--- a/readme.html
+++ b/readme.html
@@ -337,7 +337,7 @@
 				<li>Open <code>user/config.php</code> with a raw text editor (like Notepad) and fill in the required settings</li>
 				<li>Upload the unzipped files to your domain <code>public_html</code> or <code>www</code> folder</li>
 				<li>Create a new database (see <a href="#Config" onclick="toggle(this);">Configuration</a> &ndash; you can also use an existing one)</li>
-				<li>Point your browser to <code>http://yoursite.com/admin/</code></li>
+				<li>Point your browser to <code>http://your-own-domain-here.com/admin/</code></li>
 			</ol>
 			
 			<h2 id="upgrade">Upgrade</h2>
@@ -345,7 +345,7 @@
 				<li><strong>Backup the database!</strong></li>
 				<li>Unzip the YOURLS archive</li>
 				<li>Upload files to your server, overwriting your existing install</li>
-				<li>Point your browser to <code>http://yoursite.com/admin/</code></li>
+				<li>Point your browser to <code>http://your-own-domain-here.com/admin/</code></li>
 				<li>Tip: you can now move your <code>config.php</code> file to the <code>/user</code> directory</li>
 			</ol>
 			
@@ -357,7 +357,7 @@
 				<li>Unzip the YOURLS archive, upload the files</li>
 				<li>Copy <code>config-sample.php</code> to <code>config.php</code> and fill in details. <strong>Don't start with your old config file</strong>, use the new sample config file.</li>
 				<li>In your new <code>config.php</code>, add the <em>defines</em> for <code>YOURLS_DB_TABLE_URL</code> and <code>YOURLS_DB_TABLE_NEXTDEC</code> you had in your previous config file
-				<li>Point your browser to <code>http://yoursite.com/admin/</code> and follow instructions</li>
+				<li>Point your browser to <code>http://your-own-domain-here.com/admin/</code> and follow instructions</li>
 				<li>After upgrade is well and over, remove the define <code>YOURLS_DB_TABLE_NEXTDEC</code> from your config file</li>
 			</ol>
 			
@@ -469,7 +469,7 @@
 			</ul>
 			
 			<h3 id="apiusage">Usage</h3>
-			<p>You need to send parameters to <code>http://yoursite.com/yourls-api.php</code> either via <code>GET</code> or <code>POST</code> (remember to <strong></strong>URL encode parameters</strong> if via GET). These parameters are:</p>
+			<p>You need to send parameters to <code>http://your-own-domain-here.com/yourls-api.php</code> either via <code>GET</code> or <code>POST</code> (remember to <strong></strong>URL encode parameters</strong> if via GET). These parameters are:</p>
 			<ul>
 				<li>A valid <code>username</code> / <code>password</code> pair, or your <code>signature</code> (see <a href="http://yourls.org/passwordlessapi">Passwordless API requests</a>)</li>
 				<li>The requested <code>action</code>: <tt>"shorturl"</tt> (get short URL for a link), <tt>"expand"</tt> (get long URL of a shorturl), <tt>"url-stats"</tt> (get stats about one short URL), <tt>"stats"</tt> (get stats about your links) or <tt>"db-stats"</tt> (get global link and click count)</li>

--- a/sample-public-front-page.txt
+++ b/sample-public-front-page.txt
@@ -13,7 +13,7 @@
 // Start YOURLS engine
 require_once( dirname(__FILE__).'/includes/load-yourls.php' );
 
-// Change this to match the URL of your public interface. Something like: http://yoursite.com/index.php
+// Change this to match the URL of your public interface. Something like: http://your-own-domain-here.com/index.php
 $page = YOURLS_SITE . '/sample-public-front-page.php' ;
 
 // Part to be executed if FORM has been submitted

--- a/sample-remote-api-call.txt
+++ b/sample-remote-api-call.txt
@@ -21,7 +21,7 @@ $title   = 'Super blog!';                // optional, if omitted YOURLS will loo
 $format  = 'json';                       // output format: 'json', 'xml' or 'simple'
 
 // EDIT THIS: the URL of the API file
-$api_url = 'http://yoursite/yourls-api.php';
+$api_url = 'http://your-own-domain-here.com/yourls-api.php';
 
 // Init the CURL session
 $ch = curl_init();

--- a/user/config-sample.php
+++ b/user/config-sample.php
@@ -31,8 +31,8 @@ define( 'YOURLS_DB_PREFIX', 'yourls_' );
  */
 
 /** YOURLS installation URL -- all lowercase and with no trailing slash.
- ** If you define it to "http://site.com", don't use "http://www.site.com" in your browser (and vice-versa) */
-define( 'YOURLS_SITE', 'http://site.com' );
+ ** If you define it to "http://sho.rt", don't use "http://www.sho.rt" in your browser (and vice-versa) */
+define( 'YOURLS_SITE', 'http://your-own-domain-here.com' );
 
 /** Timezone GMT offset */
 define( 'YOURLS_HOURS_OFFSET', 0 ); 

--- a/yourls-loader.php
+++ b/yourls-loader.php
@@ -17,7 +17,7 @@ if ( '/robots.txt' == $_SERVER['REQUEST_URI'] ) {
 // Start YOURLS
 require_once( dirname( __FILE__ ) . '/includes/load-yourls.php' );
 
-// Get request in YOURLS base (eg in 'http://site.com/yourls/abcd' get 'abdc')
+// Get request in YOURLS base (eg in 'http://sho.rt/yourls/abcd' get 'abdc')
 $request = yourls_get_request();
 
 // Make valid regexp pattern from authorized charset in keywords


### PR DESCRIPTION
In config, readmes, editable files: the generic YOURLS install will be http://your-own-domain-here.com/ so that noob users get an obvious warning when they misconfigure something

In source comments, presumably read by hackers who have a clue, the generic YOURLS install will be http://sho.rt/. The generic long URL can be http://example.com/something-whatever

Closes #1841