### PR TITLE
add HTML5 tag and ARIA landmark

### DIFF
--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -61,6 +61,7 @@ yourls_html_logo();
 yourls_html_menu();
 ?>
 
+	<main role="main">
 	<h2><?php yourls_e( 'Plugins' ); ?></h2>
 	
 	<?php
@@ -160,6 +161,6 @@ yourls_html_menu();
 	<h3><?php yourls_e( 'More plugins' ); ?></h3>
 	
 	<p><?php yourls_e( 'For more plugins, head to the official <a href="http://yourls.org/pluginlist">Plugin list</a>.' ); ?></p>
-
+	</main>
 	
 <?php yourls_html_footer(); ?>

--- a/admin/tools.php
+++ b/admin/tools.php
@@ -8,8 +8,9 @@ yourls_html_logo();
 yourls_html_menu();
 ?>
 
-	<div class="sub_wrap">
-	
+	<div class="sub_wrap">	
+	<main role="main">
+
 	<h2><?php yourls_e( 'Bookmarklets' ); ?></h2>
 	
 		<p><?php yourls_e( 'YOURLS comes with handy <span>bookmarklets</span> for easier link shortening and sharing.' ); ?></p>
@@ -329,7 +330,8 @@ $signature = md5( $timestamp . '<?php echo yourls_auth_signature(); ?>' );
 	</ul>
 	
 	<p><?php yourls_se( 'See the <a href="%s">API documentation</a> for more', YOURLS_SITE . '/readme.html#API' ); ?></p>
-
+		
+	</main>	
 	</div>
 
 	<?php } // end is private ?>

--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -7,10 +7,12 @@
 function yourls_html_logo() {
 	yourls_do_action( 'pre_html_logo' );
 	?>
+	<header role="banner">
 	<h1>
 		<a href="<?php echo yourls_admin_url( 'index.php' ) ?>" title="YOURLS"><span>YOURLS</span>: <span>Y</span>our <span>O</span>wn <span>URL</span> <span>S</span>hortener<br/>
 		<img src="<?php yourls_site_url(); ?>/images/yourls-logo.png" alt="YOURLS" title="YOURLS" border="0" style="border: 0px;" /></a>
 	</h1>
+	</header>
 	<?php
 	yourls_do_action( 'html_logo' );
 }
@@ -140,14 +142,14 @@ function yourls_html_footer() {
 	
 	$num_queries = sprintf( yourls_n( '1 query', '%s queries', $ydb->num_queries ), $ydb->num_queries );
 	?>
-	</div> <?php // wrap ?>
-	<div id="footer"><p>
+	</div><?php // wrap ?>
+	<div id="footer"><footer role="contentinfo"><p>
 		<?php
 		$footer  = yourls_s( 'Powered by %s', '<a href="http://yourls.org/" title="YOURLS">YOURLS</a> v ' . YOURLS_VERSION );
 		$footer .= ' &ndash; '.$num_queries;
 		echo yourls_apply_filter( 'html_footer_text', $footer );
 		?>
-	</p></div>
+	</p></footer></div>
 	<?php if( defined( 'YOURLS_DEBUG' ) && YOURLS_DEBUG == true ) {
 		echo '<div style="text-align:left"><pre>';
 		echo join( "\n", $ydb->debug_log );
@@ -167,6 +169,7 @@ function yourls_html_footer() {
  */
 function yourls_html_addnew( $url = '', $keyword = '' ) {
 	?>
+	<main role="main">
 	<div id="new_url">
 		<div>
 			<form id="new_url_form" action="" method="get">
@@ -665,7 +668,7 @@ function yourls_table_tbody_end() {
  *
  */
 function yourls_table_end() {
-	echo yourls_apply_filter( 'table_end', '</table>' );
+	echo yourls_apply_filter( 'table_end', '</table></main>' );
 }
 
 /**
@@ -757,7 +760,7 @@ function yourls_html_menu() {
 	$admin_sublinks = yourls_apply_filter( 'admin_sublinks', $admin_sublinks );
 	
 	// Now output menu
-	echo '<ul id="admin_menu">'."\n";
+	echo '<nav role="navigation"><ul id="admin_menu">'."\n";
 	if ( yourls_is_private() && !empty( $logout_link ) )
 		echo '<li id="admin_menu_logout_link">' . $logout_link .'</li>';
 
@@ -785,7 +788,7 @@ function yourls_html_menu() {
 		echo '<li id="admin_menu_help_link">' . $help_link .'</li>';
 		
 	yourls_do_action( 'admin_menu' );
-	echo "</ul>\n";
+	echo "</ul></nav>\n";
 	yourls_do_action( 'admin_notices' );
 	yourls_do_action( 'admin_notice' ); // because I never remember if it's 'notices' or 'notice'
 	/*

--- a/readme.html
+++ b/readme.html
@@ -242,8 +242,11 @@
 <div id="Container">
 
 	<!-- Title -->
+	<header role="banner">
 	<h1><a href="http://yourls.org/">YOURLS: <span>Y</span>our <span>O</span>wn <span>URL</span> <span>S</span>hortener</a></h1>
-
+	</header>
+	
+	<main role="main">
 	<!-- Tabs -->
 	<ul id="Tabs">
 		<li id="MoreTab" class="Tab"><a href="#More" onclick="toggle(this);">More</a></li>
@@ -809,6 +812,7 @@ echo $data->longurl;</tt></pre>
 				
 		</div>
 	</div> <!-- content -->
+	</main>
 </div> <!-- container -->
 
 <div id="fade"></div>


### PR DESCRIPTION
I added HTML5 tag (`header nav footer main`) and ARIA landmark (`navigation main banner contentinfo`) on templates.
[See WAI-ARIA recommendation ](http://www.w3.org/TR/wai-aria/roles#landmark_roles_header) 

No design impact (no need to modify CSS files)

And that's really good for screen reader users :-)

If interested, i can go further and I can work on making it all accessible, as I done for our society installation.