### PR TITLE
Fix CSS on the admin page

### DIFF
--- a/includes/functions-themes.php
+++ b/includes/functions-themes.php
@@ -136,7 +136,7 @@ function yourls_core_assets() {
 			'yourls'    => 'yourls',
 		),
 		'css' => array(
-			'style'     => 'yourls',
+			'style'     => 'yourls.min',
 		),
 	);
 }


### PR DESCRIPTION
Currently, the admin pages of 2.0 link to yourls.css, but the file is actually called yourls.min.css. This corrects that and enables the CSS to work.