### PR TITLE
Make password auto encryption work when password contains slash(es)

### DIFF
--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -170,7 +170,7 @@ function yourls_hash_passwords_now( $config_file ) {
 			// PHP would interpret $ as a variable, so replace it in storage.
 			$hash = str_replace( '$', '!', $hash );
 			$quotes = "'" . '"';
-			$pattern = "/[$quotes]${user}[$quotes]\s*=>\s*[$quotes]" . preg_quote( $password, '-' ) . "[$quotes]/";
+			$pattern = "/[$quotes]${user}[$quotes]\s*=>\s*[$quotes]" . preg_quote( $password, '/' ) . "[$quotes]/";
 			$replace = "'$user' => 'phpass:$hash' /* Password encrypted by YOURLS */ ";
 			$count = 0;
 			$configdata = preg_replace( $pattern, $replace, $configdata, -1, $count );


### PR DESCRIPTION
Fix #1987 