### PR TITLE
Fixing markup and comment

### DIFF
--- a/yourls-infos.php
+++ b/yourls-infos.php
@@ -198,7 +198,7 @@ if( yourls_do_log_redirect() ) {
 	echo "last_24h: "; print_r( $last_24h );
 	echo "countries: "; print_r( $countries );
 	die();
-	/**/
+	**/
 
 }
 
@@ -378,7 +378,7 @@ yourls_html_menu();
 				$best_time['month'] = date( "m", strtotime( $best['day'] ) );
 				$best_time['year']  = date( "Y", strtotime( $best['day'] ) );
 				?>
-				<p><strong><?php echo sprintf( /* //translators: eg. 43 hits on January 1, 1970 */ yourls_n( '<strong>%1$s</strong> hit on %2$s', '<strong>%1$s</strong> hits on %2$s', $best['max'] ), $best['max'],  yourls_date_i18n( "F j, Y", strtotime( $best['day'] ) ) ); ?>. 
+				<p><?php echo sprintf( /* //translators: eg. 43 hits on January 1, 1970 */ yourls_n( '<strong>%1$s</strong> hit on %2$s', '<strong>%1$s</strong> hits on %2$s', $best['max'] ), $best['max'],  yourls_date_i18n( "F j, Y", strtotime( $best['day'] ) ) ); ?>. 
 				<a href="" class='details hide-if-no-js' id="more_clicks"><?php yourls_e( 'Click for more details' ); ?></a></p>
 				<ul id="details_clicks" style="display:none">
 					<?php


### PR DESCRIPTION
Minor fixes in yourls-infos.php: 
1. Removes an unclosed and superfluous `<strong>` tag in the line reading e.g.  '43 hits on January 1, 1970'. This caused wrong HTML and therefore most browsers rendered *all* dates in the list appearing on click of 'Click for more details' with bold font-weight (i.e., not only those of the best year / month / day as intended).
2. Took the liberty of also changing a closing comment token from `/**/` to the more common `**/` (in the comment titled 'I can haz debug data'). While this was perfectly valid code, it confused the syntax highlighter of github (all past the `/**/` appeared in a frightening red).