### PR TITLE
Go to First Page -> Go to Last Page

### DIFF
--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -312,7 +312,7 @@ function yourls_html_tfooter( $params = array() ) {
 					if( ( $p_end ) < $total_pages ) {
 						$link = yourls_add_query_arg( array_merge( $params, array( 'page' => $total_pages ) ), $base_page );
 						echo '<span class="nav_link nav_next"></span>';
-						echo '<span class="nav_link nav_last"><a href="' . $link . '" title="' . yourls_esc_attr__('Go to First Page') . '">' . yourls__( 'Last &raquo;' ) . '</a></span>';
+						echo '<span class="nav_link nav_last"><a href="' . $link . '" title="' . yourls_esc_attr__('Go to Last Page') . '">' . yourls__( 'Last &raquo;' ) . '</a></span>';
 					}
 					?>
 				<?php } ?>


### PR DESCRIPTION
Fixes a minor glitch in `yourls_html_tfooter()` in functions-html.php:

In the pagination section of the URL table, the 'Go to Last Page'-link has a `title` attribute 'Go to First Page' (one can notice that by hovering it). Should of course be titled 'Go to Last Page'.