### PR TITLE
Updating total clicks on delete

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -286,7 +286,7 @@ if ( !$is_bookmark ) { ?>
 			echo ", " . sprintf( yourls_n( 'counting <strong>1</strong> click', 'counting <strong>%s</strong> clicks', $total_items_clicks ), yourls_number_format_i18n( $total_items_clicks ) );
 	?>.</p>
 <?php } ?>
-<p><?php printf( yourls__( 'Overall, tracking <strong class="increment">%1$s</strong> links, <strong id="total_clicks">%2$s</strong> clicks, and counting!' ), yourls_number_format_i18n( $total_urls ), yourls_number_format_i18n( $total_clicks ) ); ?></p>
+<p id="overall_tracking"><?php printf( yourls__( 'Overall, tracking <strong class="increment">%1$s</strong> links, <strong>%2$s</strong> clicks, and counting!' ), yourls_number_format_i18n( $total_urls ), yourls_number_format_i18n( $total_clicks ) ); ?></p>
 <?php
 
 yourls_do_action( 'admin_page_before_form' );

--- a/admin/index.php
+++ b/admin/index.php
@@ -286,7 +286,7 @@ if ( !$is_bookmark ) { ?>
 			echo ", " . sprintf( yourls_n( 'counting <strong>1</strong> click', 'counting <strong>%s</strong> clicks', $total_items_clicks ), yourls_number_format_i18n( $total_items_clicks ) );
 	?>.</p>
 <?php } ?>
-<p><?php printf( yourls__( 'Overall, tracking <strong class="increment">%1$s</strong> links, <strong>%2$s</strong> clicks, and counting!' ), yourls_number_format_i18n( $total_urls ), yourls_number_format_i18n( $total_clicks ) ); ?></p>
+<p><?php printf( yourls__( 'Overall, tracking <strong class="increment">%1$s</strong> links, <strong id="total_clicks">%2$s</strong> clicks, and counting!' ), yourls_number_format_i18n( $total_urls ), yourls_number_format_i18n( $total_clicks ) ); ?></p>
 <?php
 
 yourls_do_action( 'admin_page_before_form' );

--- a/js/insert.js
+++ b/js/insert.js
@@ -197,7 +197,8 @@ function decrement_counter() {
 
 // Decrease number of total clicks
 function decrease_total_clicks( id ) {
-	$('#total_clicks').html( parseInt( $('#total_clicks').html() ) - parseInt( $('#clicks-' + id).html() ) );
+	var total_clicks = $("#overall_tracking strong:nth-child(2)");
+	total_clicks.html( parseInt( total_clicks.html() ) - parseInt( $('#clicks-' + id).html() ) );
 }
 
 // Toggle Share box

--- a/js/insert.js
+++ b/js/insert.js
@@ -111,6 +111,7 @@ function remove_link(id) {
 					zebra_table();
 				});
 				decrement_counter();
+				decrease_total_clicks( id );
 			} else {
 				alert('something wrong happened while deleting :/');
 			}
@@ -192,6 +193,11 @@ function decrement_counter() {
 	$('.increment').each(function(){
 		$(this).html( parseInt($(this).html()) - 1 );
 	});
+}
+
+// Decrease number of total clicks
+function decrease_total_clicks( id ) {
+	$('#total_clicks').html( parseInt( $('#total_clicks').html() ) - parseInt( $('#clicks-' + id).html() ) );
 }
 
 // Toggle Share box


### PR DESCRIPTION
This PR fixes the following bug:

Let us assume we have a keyword with a non-zero number of clicks. 
If the respective row of the URL/keyword table in the admin panel is deleted (via the 'Delete' button in the 'Actions' column), the total number of URLs (or links, respectively) is properly updated (i.e., decremented) in the summary on the top of the page, but the total number of clicks (i.e., the '{x}' in '{x} clicks, and counting!') remains unchanged.

This bug exists at least since v1.7.0.

To reproduce the bug, create a new keyword (say, a new custom keyword '4test') and give it a few clicks (by clicking the link in the 'Short URL' column of the respective new row for '4test', or by visiting 'http://{your-yourls-domain.tld}/4test' a few times). Now, after a refresh of the admin page, memorize or write down the number of total clicks as stated in the summary line '{x} clicks, and counting!'. Delete the row for '4test' by clicking the 'Delete' button in the 'Actions' row. Sadly, '{x}' is not decreased, but shows the same value as before.

Fix: First granted the `<strong>` tag containing the number of total clicks its own id (in admin/index.php) - the element should be prominent enough to deserve it. Added a function `decrease_total_clicks( id )` in js/insert.js which decreases that element by the value contained in the element `$('#clicks-' + id)` (i.e. by the value picked from the 'Clicks' column of the respective deleted row). Now called this method at the appropriate place in function `remove_link(id)`, thereby passing on `id` as parameter.

Please advise if you have different preferences for naming and/or coding style - PR will be updated accordingly.