### PR TITLE
Make YOURLS_SITE able to be different from installpath 'YOURLS_URL'

### DIFF
--- a/admin/tools.php
+++ b/admin/tools.php
@@ -309,7 +309,7 @@ TUMBLR;
 		<ul>
 			<li><h3><?php yourls_e( 'Usage of the signature token' ); ?></h3>
 			<p><?php yourls_e( 'Simply use parameter <tt>signature</tt> in your API requests. Example:' ); ?></p>
-			<p><code><?php echo YOURLS_SITE; ?>/yourls-api.php?signature=<?php echo yourls_auth_signature(); ?>&action=...</code></p>
+			<p><code><?php echo YOURLS_URL; ?>/yourls-api.php?signature=<?php echo yourls_auth_signature(); ?>&action=...</code></p>
 			</li>
 		
 			<li><h3><?php yourls_e( 'Usage of a time limited signature token' ); ?></h3>
@@ -321,14 +321,14 @@ $signature = md5( $timestamp . '<?php echo yourls_auth_signature(); ?>' );
 ?> 
 </code></pre>
 		<p><?php yourls_e( 'Now use parameters <tt>signature</tt> and <tt>timestamp</tt> in your API requests. Example:' ); ?></p>
-		<p><code><?php echo YOURLS_SITE; ?>/yourls-api.php?timestamp=<strong>$timestamp</strong>&signature=<strong>$signature</strong>&action=...</code></p>
+		<p><code><?php echo YOURLS_URL; ?>/yourls-api.php?timestamp=<strong>$timestamp</strong>&signature=<strong>$signature</strong>&action=...</code></p>
 		<p><?php yourls_e( 'Actual values:' ); ?><br/>
-		<tt><?php echo YOURLS_SITE; ?>/yourls-api.php?timestamp=<?php echo $time; ?>&signature=<?php echo $sign; ?>&action=...</tt></p>
+		<tt><?php echo YOURLS_URL; ?>/yourls-api.php?timestamp=<?php echo $time; ?>&signature=<?php echo $sign; ?>&action=...</tt></p>
 		<p><?php yourls_se( 'This URL would be valid for only %s seconds', YOURLS_NONCE_LIFE ); ?></p>
 		</li>
 	</ul>
 	
-	<p><?php yourls_se( 'See the <a href="%s">API documentation</a> for more', YOURLS_SITE . '/readme.html#API' ); ?></p>
+	<p><?php yourls_se( 'See the <a href="%s">API documentation</a> for more', YOURLS_URL . '/readme.html#API' ); ?></p>
 
 	</main>
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -923,7 +923,7 @@ function yourls_geo_countrycode_to_countryname( $code ) {
  */
 function yourls_geo_get_flag( $code ) {
 	if( file_exists( YOURLS_INC.'/geo/flags/flag_'.strtolower($code).'.gif' ) ) {
-		$img = yourls_match_current_protocol( YOURLS_SITE.'/includes/geo/flags/flag_'.( strtolower( $code ) ).'.gif' );
+		$img = yourls_match_current_protocol( YOURLS_URL.'/includes/geo/flags/flag_'.( strtolower( $code ) ).'.gif' );
 	} else {
 		$img = false;
 	}
@@ -1747,7 +1747,7 @@ function yourls_needs_ssl() {
  *
  */
 function yourls_admin_url( $page = '' ) {
-	$admin = YOURLS_SITE . '/admin/' . $page;
+	$admin = YOURLS_URL . '/admin/' . $page;
 	if( yourls_is_ssl() or yourls_needs_ssl() ) {
         $admin = yourls_set_url_scheme( $admin, 'https' );
     }
@@ -1760,7 +1760,7 @@ function yourls_admin_url( $page = '' ) {
  */
 function yourls_site_url( $echo = true, $url = '' ) {
 	$url = yourls_get_relative_url( $url );
-	$url = trim( YOURLS_SITE . '/' . $url, '/' );
+	$url = trim( YOURLS_URL . '/' . $url, '/' );
 	
 	// Do not enforce (checking yourls_need_ssl() ) but check current usage so it won't force SSL on non-admin pages
 	if( yourls_is_ssl() ) {

--- a/includes/load-yourls.php
+++ b/includes/load-yourls.php
@@ -25,6 +25,10 @@ if( !defined( 'YOURLS_DB_PREFIX' ) )
 if( !defined( 'YOURLS_ABSPATH' ) )
 	define( 'YOURLS_ABSPATH', str_replace( '\\', '/', dirname( dirname( __FILE__ ) ) ) );
 
+// URL of YOURLS root
+if( !defined( 'YOURLS_URL' ) )
+	define( 'YOURLS_URL', YOURLS_SITE );
+
 // physical path of includes directory
 if( !defined( 'YOURLS_INC' ) )
 	define( 'YOURLS_INC', YOURLS_ABSPATH.'/includes' );
@@ -35,7 +39,7 @@ if( !defined( 'YOURLS_USERDIR' ) )
 
 // URL of user directory
 if( !defined( 'YOURLS_USERURL' ) )
-	define( 'YOURLS_USERURL', YOURLS_SITE.'/user' );
+	define( 'YOURLS_USERURL', YOURLS_URL.'/user' );
 	
 // physical path of translations directory
 if( !defined( 'YOURLS_LANG_DIR' ) )
@@ -173,7 +177,7 @@ if( !yourls_is_installed() && !yourls_is_installing() ) {
 // Check if upgrade is needed (bypassed if upgrading or installing)
 if ( !yourls_is_upgrading() && !yourls_is_installing() ) {
 	if ( yourls_upgrade_is_needed() ) {
-		yourls_redirect( YOURLS_SITE .'/admin/upgrade.php', 302 );
+		yourls_redirect( YOURLS_URL.'/admin/upgrade.php', 302 );
 	}
 }
 

--- a/user/config-sample.php
+++ b/user/config-sample.php
@@ -35,13 +35,13 @@ define( 'YOURLS_DB_PREFIX', 'yourls_' );
 define( 'YOURLS_SITE', 'http://your-own-domain-here.com' );
 
 /** Server timezone GMT offset */
-define( 'YOURLS_HOURS_OFFSET', 0 ); 
+define( 'YOURLS_HOURS_OFFSET', 0 );
 
 /** YOURLS language
  ** Change this setting to use a translation file for your language, instead of the default English.
  ** That translation file (a .mo file) must be installed in the user/language directory.
  ** See http://yourls.org/translations for more information */
-define( 'YOURLS_LANG', '' ); 
+define( 'YOURLS_LANG', '' );
 
 /** Allow multiple short URLs for a same long URL
  ** Set to true to have only one pair of shortURL/longURL (default YOURLS behavior)
@@ -68,7 +68,7 @@ $yourls_user_passwords = array(
 /** Debug mode to output some internal information
  ** Default is false for live site. Enable when coding or before submitting a new issue */
 define( 'YOURLS_DEBUG', false );
-	
+
 /*
  ** URL Shortening settings
  */
@@ -81,7 +81,7 @@ define( 'YOURLS_URL_CONVERT', 36 );
  * Stick to one setting. It's best not to change after you've started creating links.
  */
 
-/** 
+/**
 * Reserved keywords (so that generated URLs won't match them)
 * Define here negative, unwanted or potentially misleading keywords.
 */

--- a/yourls-infos.php
+++ b/yourls-infos.php
@@ -225,7 +225,7 @@ yourls_html_menu();
 } else {
 	yourls_html_link( yourls_link($keyword) );
 	if( isset( $keyword_list ) && count( $keyword_list ) > 1 )
-		echo ' <a href="'. yourls_link($keyword).'+all" title="' . yourls_esc_attr__( 'Aggregate stats for duplicate short URLs' ) . '"><img src="' . yourls_match_current_protocol( YOURLS_SITE ) . '/images/chart_bar_add.png" border="0" /></a>';
+		echo ' <a href="'. yourls_link($keyword).'+all" title="' . yourls_esc_attr__( 'Aggregate stats for duplicate short URLs' ) . '"><img src="' . yourls_match_current_protocol( YOURLS_URL ) . '/images/chart_bar_add.png" border="0" /></a>';
 } ?></h3>
 <h3 id="longurl"><span class="label"><?php yourls_e( 'Long URL'); ?>:</span> <img class="fix_images" src="<?php echo yourls_get_favicon_url( $longurl );?>" /> <?php yourls_html_link( $longurl, yourls_trim_long_string( $longurl ), 'longurl' ); ?></h3>
 


### PR DESCRIPTION
This makes it possible that YOURLS can be installed in a subdirectory of your web root, so that your web root is not cluttered up with the files of YOURLS.

This introduces a new setting YOURLS_URL where you specify the URL of your YOURLS installation so that the admin interface can work:
`define( 'YOURLS_URL', 'https://example.com/yourls' );`
This is not your short link base URL. / It can differ from it.
This setting can be ommitted if YOURLS is installed in the short link base web root as it would be normally.

Fixed some whitespace issues in ./user/config-sample.php