### PR TITLE
Re-enable cancel on exiting edit_link_save()

### DIFF
--- a/js/insert.js
+++ b/js/insert.js
@@ -163,6 +163,7 @@ function edit_link_save(id) {
 			}
 			feedback(data.message, data.status);
 			end_loading("#edit-close-" + id);
+			end_disable("#edit-close-" + id);
 			end_disable("#actions-" + id + ' .button');
 		}
 	);


### PR DESCRIPTION
Fixes a flaw in `edit_link_save()` in insert.js:

On exit, `edit_link_save()` correctly ends the loading state of the cancel button (i.e. the element with id `edit-close-y...`), but leaves the element disabled. This gets evident if and only if the ajax call (`action=edit_save`) returns with a `status` of `fail`, since only then the edit row with the disabled cancel button will not be faded out.

The flaw exists at least since v1.7.0.

To reproduce the problem on e.g. a fresh install, click the edit button of an arbitrary row of the table in the admin panel. Then, without editing anything(!), click the save button. You will get the correct notification 'Error updating {trimmed longurl} Short URL: {untrimmed keyword}' because there is nothing (i.e. no change) to save yet. The edit row remains visible. Now click the cancel button: Nada, the edit row can not be cancelled and remains visible.

Fix: Added a line calling `end_disable('#edit-close-' + id)` before exiting the function (regardless of the value of `status`).