### PR TITLE
Removes an ineffective line of code

### DIFF
--- a/js/insert.js
+++ b/js/insert.js
@@ -154,7 +154,6 @@ function edit_link_save(id) {
 
 				$("#url-" + id).html(display_link);
 				$("#keyword-" + id).html('<a href="' + data.url.shorturl + '" title="' + data.url.shorturl + '">' + data.url.keyword + '</a>');
-				$("#timestamp-" + id).html(data.url.date);
 				$("#edit-" + id).fadeOut(200, function(){
 					$('#main_table tbody').trigger("update");
 				});


### PR DESCRIPTION
This PR removes an ineffective line of code in `edit_link_save()` with an undefined variable `data.url.date` (this is because `data.url.date` is not set in the function invoked via ajax, i.e. in `yourls_edit_link()` in functions.php).
 
Most probably this is just a leftover. Then the line should be deleted (as done in this PR). 

If however you should (now) want to update the timestamp on edition, more code needs to be added to `yourls_edit_link()`: i.e. including the current timestamp into the update query, e.g. by setting `$timestamp = date( 'Y-m-d H:i:s' );`, followed by a query like e.g. `$update_url = $ydb->query( "UPDATE `$table` SET `url` = '$url', `keyword` = '$newkeyword', `timestamp` = '$timestamp', `title` = '$title' WHERE `keyword` = '$keyword';" );`, and then finally adding `'date' => $timestamp` to the hash/associative array returned in `$return['url']` (much like it is already done in function `yourls_add_new_link` in functions.php). 

In the latter case: just give me a nod, and I should be able to update the PR appropiately.