### PR TITLE
Correcting title attr. of display_link

### DIFF
--- a/js/insert.js
+++ b/js/insert.js
@@ -147,7 +147,7 @@ function edit_link_save(id) {
 			if(data.status == 'success') {
 			
 				if( data.url.title != '' ) {
-					var display_link = '<a href="' + data.url.url + '" title="' + data.url.url + '">' + data.url.display_title + '</a><br/><small><a href="' + data.url.url + '">' + data.url.display_url + '</a></small>';
+					var display_link = '<a href="' + data.url.url + '" title="' + data.url.title + '">' + data.url.display_title + '</a><br/><small><a href="' + data.url.url + '">' + data.url.display_url + '</a></small>';
 				} else {
 					var display_link = '<a href="' + data.url.url + '" title="' + data.url.url + '">' + data.url.display_url + '</a>';
 				}


### PR DESCRIPTION
Fixes a minor glitch in `edit_link_save` in insert.js:

Problem / How to reproduce:

After edition of an URL's title, the `title` attribute of the display title (as visible on hovering the display title) is replaced by the (untrimmed) long URL. This is unexpected/inconsistent behavior [behaviour] since in contrast, for an existing unedited URL title, the respective `title` attribute is simply the (untrimmed) title itself (see the line `'title_attr'    => yourls_esc_attr( $title ),` in `yourls_table_add_row` in functions-html.php: cf. https://github.com/YOURLS/YOURLS/blob/cb86f5b6ff6f4beb4ec525f0b830e122f8f31016/includes/functions-html.php#L561).

Fix: 
Plugging in `data.url.title` as (untrimmed) `title` attribute (instead of plugging in `data.url.url`) when setting the variable `display_link`.