### PR TITLE
Access-Control-Allow-Origin for ajax calls on CNAMES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ Desktop.ini
 
 # Mac crap
 .DS_Store
+
+# IDEs
+.idea

--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -908,6 +908,7 @@ function yourls_content_type_header( $type ) {
 	if( !headers_sent() ) {
 		$charset = yourls_apply_filter( 'content_type_header_charset', 'utf-8' );
 		header( "Content-Type: $type; charset=$charset" );
+		header("Access-Control-Allow-Origin: "+YOURLS_SITE);
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Add CORS header fix for same domain, else ajax calls for actions will break if using DNS CNAMES.