### PR TITLE
Added a "delete" API action to delete a specific shorturl

### DIFF
--- a/includes/functions-api.php
+++ b/includes/functions-api.php
@@ -83,6 +83,18 @@ function yourls_api_action_version() {
 }
 
 /**
+ * API function wrapper: delete a shorturl
+ *
+ * @return array Result of API call
+ */
+function yourls_api_action_delete() {
+	$keyword = ( isset( $_REQUEST['keyword'] ) ? $_REQUEST['keyword'] : '' );
+	$query = yourls_delete_link_by_keyword($keyword);
+	$return = array( 'success' => $query === 1 );
+	return yourls_apply_filter( 'api_result_delete', $return, $keyword);
+}
+
+/**
  * Output and return API result
  *
  * This function will echo (or only return if asked) an array as JSON, JSONP or XML. If the array has a

--- a/readme.html
+++ b/readme.html
@@ -476,7 +476,9 @@
 			<p>You need to send parameters to <code>http://your-own-domain-here.com/yourls-api.php</code> either via <code>GET</code> or <code>POST</code> (remember to <strong></strong>URL encode parameters</strong> if via GET). These parameters are:</p>
 			<ul>
 				<li>A valid <code>username</code> / <code>password</code> pair, or your <code>signature</code> (see <a href="http://yourls.org/passwordlessapi">Passwordless API requests</a>)</li>
-				<li>The requested <code>action</code>: <tt>"shorturl"</tt> (get short URL for a link), <tt>"expand"</tt> (get long URL of a shorturl), <tt>"url-stats"</tt> (get stats about one short URL), <tt>"stats"</tt> (get stats about your links) or <tt>"db-stats"</tt> (get global link and click count)</li>
+				<li>The requested <code>action</code>: <tt>"shorturl"</tt> (get short URL for a link), <tt>"expand"</tt> (get long URL of a shorturl), 
+<tt>"url-stats"</tt> (get stats about one short URL), <tt>"stats"</tt> (get stats about your links), <tt>"db-stats"</tt> (get global link and click count) or 
+<tt>"delete" (remove a shorturl)</li>
 				<li>With <tt>action = "shorturl"</tt> :
 					<ul>
 						<li>the <code>url</code> to shorten</li>
@@ -505,6 +507,12 @@
 				</li>
 				<li>With <tt>action = "db-stats"</tt> :
 					<ul>
+						<li>output <code>format</code>: either <tt>"jsonp"</tt>, <tt>"json"</tt> or <tt>"xml"</tt></li>
+					</ul>
+				</li>
+				<li>With <tt>action = "delete"</tt> :
+					<ul>
+						<li>the <code>keyword</code> of the short URL to delete</li>
 						<li>output <code>format</code>: either <tt>"jsonp"</tt>, <tt>"json"</tt> or <tt>"xml"</tt></li>
 					</ul>
 				</li>

--- a/yourls-api.php
+++ b/yourls-api.php
@@ -23,6 +23,7 @@ $api_actions = array(
 	'url-stats' => 'yourls_api_action_url_stats',
 	'expand'    => 'yourls_api_action_expand',
 	'version'   => 'yourls_api_action_version',
+	'delete'    => 'yourls_api_action_delete',
 );
 $api_actions = yourls_apply_filter( 'api_actions', $api_actions );
 


### PR DESCRIPTION
Added a "delete" API action to delete a specific given shorturl. 

I use yourls in combination with owncloud to shorten the owncloud share-links and i would like to remove shorturls when the corresponding owncloud-url is removed.