### PR TITLE
We need to run this over https

### DIFF
--- a/includes/functions-infos.php
+++ b/includes/functions-infos.php
@@ -241,7 +241,7 @@ function yourls_get_domain( $url, $include_scheme = false ) {
  *
  */
 function yourls_get_favicon_url( $url ) {
-	return yourls_match_current_protocol( 'http://www.google.com/s2/favicons?domain=' . yourls_get_domain( $url, false ) );
+	return yourls_match_current_protocol( 'https://www.google.com/s2/favicons?domain=' . yourls_get_domain( $url, false ) );
 }
 
 /**


### PR DESCRIPTION
We need to run this over https (see Google's recommendations for 2017)

Statistics page for a certain link throws a warning in the console:

```
Mixed Content: The page at 'xxxxxxxxxx' was loaded over HTTPS, but requested an insecure image 'http://www.google.com/s2/favicons?domain=xxxxxxxxxxx'. This content should also be served over HTTPS.
```