### PR TITLE
Support optional www. prefix

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1911,9 +1911,9 @@ function yourls_get_request() {
 		return $request;
 	
 	// Ignore protocol & www. prefix
-	$root = str_replace( array( 'https://', 'http://', 'https://www.', 'http://www.' ), '', YOURLS_SITE );
+	$root = str_replace( array( 'https://www.', 'http://www.', 'https://', 'http://'  ), '', YOURLS_SITE );
 	// Case insensitive comparison of the YOURLS root to match both http://Sho.rt/blah and http://sho.rt/blah
-	$request = preg_replace( "!$root/!i", '', $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], 1 );
+	$request = preg_replace( "!(?:www\.)?$root/!i", '', $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], 1 );
 
 	// Unless request looks like a full URL (ie request is a simple keyword) strip query string
 	if( !preg_match( "@^[a-zA-Z]+://.+@", $request ) ) {


### PR DESCRIPTION
Some people just insist on typing "www." into every URL.
YOURLS does not support that at the moment if `YOURLS_SITE` does not have the www\. prefix.

With this change, both http[s]://sho.rt/xyz _and_ http[s]://<b>www.</b>sho.rt/xyz will work,
no matter if `YOURLS_SITE` has a www\. prefix or not.

