### PR TITLE
Adding label to every input on index page

### DIFF
--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -181,8 +181,8 @@ function yourls_html_addnew( $url = '', $keyword = '' ) {
 	<div id="new_url">
 		<div>
 			<form id="new_url_form" action="" method="get">
-				<div><strong><?php yourls_e( 'Enter the URL' ); ?></strong>:<input type="text" id="add-url" name="url" value="<?php echo $url; ?>" class="text" size="80" placeholder="http://" />
-				<?php yourls_e( 'Optional '); ?> : <strong><?php yourls_e('Custom short URL'); ?></strong>:<input type="text" id="add-keyword" name="keyword" value="<?php echo $keyword; ?>" class="text" size="8" />
+				<div><label for="add-url"><strong><?php yourls_e( 'Enter the URL' ); ?></strong></label>:<input type="text" id="add-url" name="url" value="<?php echo $url; ?>" class="text" size="80" placeholder="http://" />
+				<label for="add-keyword"><?php yourls_e( 'Optional '); ?> : <strong><?php yourls_e('Custom short URL'); ?></strong></label>:<input type="text" id="add-keyword" name="keyword" value="<?php echo $keyword; ?>" class="text" size="8" />
 				<?php yourls_nonce_field( 'add_url', 'nonce-add' ); ?>
 				<input type="button" id="add-button" name="add-button" value="<?php yourls_e( 'Shorten The URL' ); ?>" class="button" onclick="add_link();" /></div>
 			</form>

--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -228,7 +228,7 @@ function yourls_html_tfooter( $params = array() ) {
 						<?php
 
 						// First search control: text to search
-						$_input = '<input type="text" name="search" class="text" size="12" value="' . yourls_esc_attr( $search_text ) . '" />';
+						$_input = '<input aria-label="' .yourls__( 'Search for' ). '" type="text" name="search" class="text" size="12" value="' . yourls_esc_attr( $search_text ) . '" />';
 						$_options = array(
                             'all'     => yourls__( 'All fields' ),
 							'keyword' => yourls__( 'Short URL' ),
@@ -236,7 +236,8 @@ function yourls_html_tfooter( $params = array() ) {
 							'title'   => yourls__( 'Title' ),
 							'ip'      => yourls__( 'IP' ),
 						);
-						$_select = yourls_html_select( 'search_in', $_options, $search_in );
+						$label = yourls__( 'Search in' );
+						$_select = yourls_html_select(  $label, 'search_in', $_options, $search_in);
 						/* //translators: "Search for <input field with text to search> in <select dropdown with URL, title...>" */
 						yourls_se( 'Search for %1$s in %2$s', $_input , $_select );
 						echo "&ndash;\n";
@@ -249,20 +250,23 @@ function yourls_html_tfooter( $params = array() ) {
 							'ip'           => yourls__( 'IP' ),
 							'clicks'       => yourls__( 'Clicks' ),
 						);
-						$_select = yourls_html_select( 'sort_by', $_options, $sort_by );
+						$label = yourls__( 'Sort by' );
+						$_select = yourls_html_select( $label, 'sort_by', $_options, $sort_by );
 						$sort_order = isset( $sort_order ) ? $sort_order : 'desc' ;
 						$_options = array(
 							'asc'  => yourls__( 'Ascending' ),
 							'desc' => yourls__( 'Descending' ),
 						);
-						$_select2 = yourls_html_select( 'sort_order', $_options, $sort_order );
+						$label = yourls__( 'Sort order' );
+						$_select2 = yourls_html_select( $label, 'sort_order', $_options, $sort_order );
 						/* //translators: "Order by <criteria dropdown (date, clicks...)> in <order dropdown (Descending or Ascending)>" */
 						yourls_se( 'Order by %1$s %2$s', $_select , $_select2 );
 						echo "&ndash;\n";
 
 						// Third search control: Show XX rows
 						/* //translators: "Show <text field> rows" */
-						yourls_se( 'Show %s rows',  '<input type="text" name="perpage" class="text" size="2" value="' . $perpage . '" />' );
+						$_input = '<input aria-label="' .yourls__( 'Number of rows to show' ). '" type="text" name="perpage" class="text" size="2" value="' . $perpage . '" />';
+						yourls_se( 'Show %s rows',  $_input );
 						echo "<br/>\n";
 
 						// Fourth search control: Show links with more than XX clicks
@@ -270,8 +274,9 @@ function yourls_html_tfooter( $params = array() ) {
 							'more' => yourls__( 'more' ),
 							'less' => yourls__( 'less' ),
 						);
-						$_select = yourls_html_select( 'click_filter', $_options, $click_filter );
-						$_input  = '<input type="text" name="click_limit" class="text" size="4" value="' . $click_limit . '" /> ';
+						$label = yourls__( 'Show links with' );
+						$_select = yourls_html_select( $label, 'click_filter', $_options, $click_filter );
+						$_input  = '<input aria-label="' .yourls__( 'Number of clicks' ). '" type="text" name="click_limit" class="text" size="4" value="' . $click_limit . '" /> ';
 						/* //translators: "Show links with <more/less> than <text field> clicks" */
 						yourls_se( 'Show links with %1$s than %2$s clicks', $_select, $_input );
 						echo "<br/>\n";
@@ -282,10 +287,11 @@ function yourls_html_tfooter( $params = array() ) {
 							'after'   => yourls__('after'),
 							'between' => yourls__('between'),
 						);
-						$_select = yourls_html_select( 'date_filter', $_options, $date_filter );
-						$_input  = '<input type="text" name="date_first" id="date_first" class="text" size="12" value="' . $date_first . '" />';
+						$label = yourls__('Show links created') ; 
+						$_select = yourls_html_select( $label, 'date_filter', $_options, $date_filter );
+						$_input  = '<input aria-label="' .yourls__('Select a date') . '" type="text" name="date_first" id="date_first" class="text" size="12" value="' . $date_first . '" />';
 						$_and    = '<span id="date_and"' . ( $date_filter === 'between' ? ' style="display:inline"' : '' ) . '> &amp; </span>';
-						$_input2 = '<input type="text" name="date_second" id="date_second" class="text" size="12" value="' . $date_second . '"' . ( $date_filter === 'between' ? ' style="display:inline"' : '' ) . '/>';
+						$_input2 = '<input aria-label="' .yourls__('Select an end date') . '" type="text" name="date_second" id="date_second" class="text" size="12" value="' . $date_second . '"' . ( $date_filter === 'between' ? ' style="display:inline"' : '' ) . '/>';
 						/* //translators: "Show links created <before/after/between> <date input> <"and" if applicable> <date input if applicable>" */
 						yourls_se( 'Show links created %1$s %2$s %3$s %4$s', $_select, $_input, $_and, $_input2 );
 						?>
@@ -359,8 +365,8 @@ function yourls_html_tfooter( $params = array() ) {
  * @param boolean $display false (default) to return, true to echo
  * @return string HTML content of the select element
  */
-function yourls_html_select( $name, $options, $selected = '', $display = false ) {
-	$html = "<select name='$name' id='$name' size='1'>\n";
+function yourls_html_select( $label, $name, $options, $selected = '', $display = false ) {
+	$html = "<select aria-label='$label' name='$name' id='$name' size='1'>\n";
 	foreach( $options as $value => $text ) {
 		$html .= "<option value='$value' ";
 		$html .= $selected == $value ? ' selected="selected"' : '';

--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -237,7 +237,7 @@ function yourls_html_tfooter( $params = array() ) {
 							'ip'      => yourls__( 'IP' ),
 						);
 						$label = yourls__( 'Search in' );
-						$_select = yourls_html_select(  $label, 'search_in', $_options, $search_in);
+						$_select = yourls_html_select( 'search_in', $_options, $search_in, $display, $label);
 						/* //translators: "Search for <input field with text to search> in <select dropdown with URL, title...>" */
 						yourls_se( 'Search for %1$s in %2$s', $_input , $_select );
 						echo "&ndash;\n";
@@ -251,14 +251,14 @@ function yourls_html_tfooter( $params = array() ) {
 							'clicks'       => yourls__( 'Clicks' ),
 						);
 						$label = yourls__( 'Sort by' );
-						$_select = yourls_html_select( $label, 'sort_by', $_options, $sort_by );
+						$_select = yourls_html_select( 'sort_by', $_options, $sort_by, $display, $label );
 						$sort_order = isset( $sort_order ) ? $sort_order : 'desc' ;
 						$_options = array(
 							'asc'  => yourls__( 'Ascending' ),
 							'desc' => yourls__( 'Descending' ),
 						);
 						$label = yourls__( 'Sort order' );
-						$_select2 = yourls_html_select( $label, 'sort_order', $_options, $sort_order );
+						$_select2 = yourls_html_select( 'sort_order', $_options, $sort_order, $display, $label );
 						/* //translators: "Order by <criteria dropdown (date, clicks...)> in <order dropdown (Descending or Ascending)>" */
 						yourls_se( 'Order by %1$s %2$s', $_select , $_select2 );
 						echo "&ndash;\n";
@@ -275,7 +275,7 @@ function yourls_html_tfooter( $params = array() ) {
 							'less' => yourls__( 'less' ),
 						);
 						$label = yourls__( 'Show links with' );
-						$_select = yourls_html_select( $label, 'click_filter', $_options, $click_filter );
+						$_select = yourls_html_select( 'click_filter', $_options, $click_filter, $display, $label );
 						$_input  = '<input aria-label="' .yourls__( 'Number of clicks' ). '" type="text" name="click_limit" class="text" size="4" value="' . $click_limit . '" /> ';
 						/* //translators: "Show links with <more/less> than <text field> clicks" */
 						yourls_se( 'Show links with %1$s than %2$s clicks', $_select, $_input );
@@ -288,7 +288,7 @@ function yourls_html_tfooter( $params = array() ) {
 							'between' => yourls__('between'),
 						);
 						$label = yourls__('Show links created') ; 
-						$_select = yourls_html_select( $label, 'date_filter', $_options, $date_filter );
+						$_select = yourls_html_select( 'date_filter', $_options, $date_filter, $display, $label );
 						$_input  = '<input aria-label="' .yourls__('Select a date') . '" type="text" name="date_first" id="date_first" class="text" size="12" value="' . $date_first . '" />';
 						$_and    = '<span id="date_and"' . ( $date_filter === 'between' ? ' style="display:inline"' : '' ) . '> &amp; </span>';
 						$_input2 = '<input aria-label="' .yourls__('Select an end date') . '" type="text" name="date_second" id="date_second" class="text" size="12" value="' . $date_second . '"' . ( $date_filter === 'between' ? ' style="display:inline"' : '' ) . '/>';
@@ -365,7 +365,7 @@ function yourls_html_tfooter( $params = array() ) {
  * @param boolean $display false (default) to return, true to echo
  * @return string HTML content of the select element
  */
-function yourls_html_select( $label, $name, $options, $selected = '', $display = false ) {
+function yourls_html_select( $name, $options, $selected = '', $display = false, $label = '') {
 	$html = "<select aria-label='$label' name='$name' id='$name' size='1'>\n";
 	foreach( $options as $value => $text ) {
 		$html .= "<option value='$value' ";


### PR DESCRIPTION
None of the inputs were correctly labelled, it's a problem for screen reader user (e.g. a blind person), so I try to fix it in the less invasive way : 

- Add `label` tag and id/for relation to input in the new_url form : https://www.w3.org/TR/WCAG-TECHS/H44.html
- Add `aria-label` to every input in the sort form : https://www.w3.org/TR/WCAG20-TECHS/ARIA6.html

No CSS impact, and normally, no cross browser impact. 