### PR TITLE
Fix "find config"

### DIFF
--- a/includes/YOURLS/Config/Config.php
+++ b/includes/YOURLS/Config/Config.php
@@ -23,7 +23,7 @@ class Config {
      * @param  mixed $config   Optional user defined config path
      */
     public function __construct($config = false) {
-        $this->set_root( $this->fix_win32_path(realpath(__DIR__ . '/../../../..')) );
+        $this->set_root($this->fix_win32_path( dirname(dirname(dirname(__DIR__))) ));
         $this->set_config($config);
     }
 


### PR DESCRIPTION
realpath() seems to have many caveats depending on the platform (Win/Linux/BSD) and various settings (namely, open_basedir restrictions)

Ping @boldcity and @KabataMacharia, if you could test this patch on your platform it would be very great. Currently works on Windows and Ubuntu