### PR TITLE
add Dockerfile for easy deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Configuration
 user/*
 !user/config-sample.php
+!user/config-env.php
 .htaccess
 *.config
 *.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM php:7.0-apache
+
+# copy in source and set config to env-based config
+COPY ./ /var/www/html/
+COPY ./user/config-env.php /var/www/html/user/config.php
+
+# add .htaccess file
+# this is necessary as the htaccess setup is skipped
+# if the database is already set up
+RUN echo '<IfModule mod_rewrite.c> \n \
+    RewriteEngine On \n \
+    RewriteBase / \n \
+    RewriteCond %{REQUEST_FILENAME} !-f \n \
+    RewriteCond %{REQUEST_FILENAME} !-d \n \
+    RewriteRule ^.*$ /yourls-loader.php [L] \n \
+    </IfModule>' \
+    >> /var/www/html/.htaccess 
+
+# php runtime requirements:
+# install mysqli php extension and activate modrewrite
+RUN docker-php-source extract \
+    && docker-php-ext-install mysqli \
+    && docker-php-ext-install pdo_mysql \
+    && docker-php-source delete \
+    && a2enmod rewrite
+
+# set default configuration values
+ENV YOURLS_DB_USER replaceme
+ENV YOURLS_DB_PASS replaceme
+ENV YOURLS_DB_NAME replaceme
+ENV YOURLS_DB_HOST replaceme
+ENV YOURLS_SITE http://localhost:8080
+ENV YOURLS_COOKIEKEY replaceme
+ENV YOURLS_ADMIN_PASSWORD replaceme

--- a/user/config-env.php
+++ b/user/config-env.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ ** MySQL settings - You can get this info from your web host
+ */
+
+/** MySQL database username */
+define( 'YOURLS_DB_USER', getenv('YOURLS_DB_USER') );
+
+/** MySQL database password */
+define( 'YOURLS_DB_PASS', getenv('YOURLS_DB_PASS') );
+
+/** The name of the database for YOURLS */
+define( 'YOURLS_DB_NAME', getenv('YOURLS_DB_NAME') );
+
+/** MySQL hostname.
+ ** If using a non standard port, specify it like 'hostname:port', eg. 'localhost:9999' or '127.0.0.1:666' */
+define( 'YOURLS_DB_HOST', getenv('YOURLS_DB_HOST') );
+
+/** MySQL tables prefix */
+define( 'YOURLS_DB_PREFIX', 'yourls_' );
+
+/*
+ ** Site options
+ */
+
+/** YOURLS installation URL -- all lowercase, no trailing slash at the end.
+ ** If you define it to "http://sho.rt", don't use "http://www.sho.rt" in your browser (and vice-versa) */
+define( 'YOURLS_SITE', getenv('YOURLS_SITE') );
+
+/** Server timezone GMT offset */
+define( 'YOURLS_HOURS_OFFSET', 0 ); 
+
+/** YOURLS language
+ ** Change this setting to use a translation file for your language, instead of the default English.
+ ** That translation file (a .mo file) must be installed in the user/language directory.
+ ** See http://yourls.org/translations for more information */
+define( 'YOURLS_LANG', '' ); 
+
+/** Allow multiple short URLs for a same long URL
+ ** Set to true to have only one pair of shortURL/longURL (default YOURLS behavior)
+ ** Set to false to allow multiple short URLs pointing to the same long URL (bit.ly behavior) */
+define( 'YOURLS_UNIQUE_URLS', true );
+
+/** Private means the Admin area will be protected with login/pass as defined below.
+ ** Set to false for public usage (eg on a restricted intranet or for test setups)
+ ** Read http://yourls.org/privatepublic for more details if you're unsure */
+define( 'YOURLS_PRIVATE', true );
+
+/** A random secret hash used to encrypt cookies. You don't have to remember it, make it long and complicated. Hint: copy from http://yourls.org/cookie **/
+define( 'YOURLS_COOKIEKEY', getenv('YOURLS_COOKIEKEY') );
+
+/** Username(s) and password(s) allowed to access the site. Passwords either in plain text or as encrypted hashes
+ ** YOURLS will auto encrypt plain text passwords in this file
+ ** Read http://yourls.org/userpassword for more information */
+$yourls_user_passwords = array(
+	'admin' => getenv('ADMIN_PASSWORD'),
+	// 'username2' => 'password2',
+	// You can have one or more 'login'=>'password' lines
+	);
+
+/** Debug mode to output some internal information
+ ** Default is false for live site. Enable when coding or before submitting a new issue */
+define( 'YOURLS_DEBUG', false );
+	
+/*
+ ** URL Shortening settings
+ */
+
+/** URL shortening method: 36 or 62 */
+define( 'YOURLS_URL_CONVERT', 36 );
+/*
+ * 36: generates all lowercase keywords (ie: 13jkm)
+ * 62: generates mixed case keywords (ie: 13jKm or 13JKm)
+ * Stick to one setting. It's best not to change after you've started creating links.
+ */
+
+/** 
+* Reserved keywords (so that generated URLs won't match them)
+* Define here negative, unwanted or potentially misleading keywords.
+*/
+$yourls_reserved_URL = array(
+	'porn', 'faggot', 'sex', 'nigger', 'fuck', 'cunt', 'dick',
+);
+
+/*
+ ** Personal settings would go after here.
+ */
+


### PR DESCRIPTION
This is the Dockerfile that I've been using for production; it's been working quite nicely and has the benefit of using the upstream php image to manage the installation of php and the various required php extensions.

Other alternative Dockerfiles I'd considered included [daftlabs](https://github.com/daftlabs/docker-yourls) and [tsgoff](https://github.com/tsgoff/docker-yourls), but both were unnecessarily complicated, and I figured it'd be good to have a canonical file included in the repository.

If y'all accept this, I'd happily add some documentation on setting up a local instance of YOURLS using Docker to the wiki.