### PR TITLE
Exception - Cannot find config.php - Wrong Directory Bug

### DIFF
--- a/includes/Config/Config.php
+++ b/includes/Config/Config.php
@@ -25,7 +25,7 @@ class Config {
      * @param  mixed $config   Optional user defined config path
      */
     public function __construct($config = false) {
-        $this->set_root($this->fix_win32_path( dirname(dirname(dirname(__DIR__))) ));
+        $this->set_root( $this->fix_win32_path( dirname( dirname( __DIR__ ) ) ) );
         $this->set_config($config);
     }
 


### PR DESCRIPTION
#  Subdirectory Install

The /YOURLS/ directory was removed but the dirname() structure was not
changed. Throws exception - Cannot find config.php - in subdirectory
install.