### PR TITLE
add filter to bypass yourls_html_addnew()

### DIFF
--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -176,6 +176,9 @@ function yourls_html_footer($can_query = true) {
  * @param string $keyword Keyword to prefill the input with
  */
 function yourls_html_addnew( $url = '', $keyword = '' ) {
+	$pre = yourls_apply_filter( 'shunt_html_addnew', false );
+		if ( false !== $pre )
+			return $pre;
 	?>
 	<main role="main">
 	<div id="new_url">

--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -176,7 +176,7 @@ function yourls_html_footer($can_query = true) {
  * @param string $keyword Keyword to prefill the input with
  */
 function yourls_html_addnew( $url = '', $keyword = '' ) {
-	$pre = yourls_apply_filter( 'shunt_html_addnew', false );
+	$pre = yourls_apply_filter( 'shunt_html_addnew', false, $url, $keyword  );
 		if ( false !== $pre )
 			return $pre;
 	?>

--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -176,9 +176,10 @@ function yourls_html_footer($can_query = true) {
  * @param string $keyword Keyword to prefill the input with
  */
 function yourls_html_addnew( $url = '', $keyword = '' ) {
-	$pre = yourls_apply_filter( 'shunt_html_addnew', false, $url, $keyword  );
-		if ( false !== $pre )
-			return $pre;
+    $pre = yourls_apply_filter( 'shunt_html_addnew', false, $url, $keyword );
+    if ( false !== $pre ) {
+        return $pre;
+    }
 	?>
 	<main role="main">
 	<div id="new_url">


### PR DESCRIPTION
This adds a simple filter allowing a plugin to bypass the yourls_html_addnew() function. This is useful if an alternate form with special request parameters needs to be used.