### PR TITLE
Fixed link to contributors graph.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Contributors
 ------------
 
 YOURLS is made by these fine folks :
-<a href="graphs/contributors"><img src="https://opencollective.com/yourls/contributors.svg?width=890" /></a>
+<a href="https://github.com/YOURLS/YOURLS/graphs/contributors"><img src="https://opencollective.com/yourls/contributors.svg?width=890" /></a>
 
 License
 -------


### PR DESCRIPTION
I simply fixed the URL to the contributors graph, before it was giving me a 404 error, because it was taking me here: https://github.com/YOURLS/YOURLS/blob/master/graphs/contributors 