### PR TITLE
Remove referrer meta tag from admin head

### DIFF
--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -86,7 +86,6 @@ function yourls_html_head( $context = 'index', $title = '' ) {
 	<meta http-equiv="Content-Type" content="<?php echo yourls_apply_filter( 'html_head_meta_content-type', 'text/html; charset=utf-8' ); ?>" />
 	<meta name="generator" content="YOURLS <?php echo YOURLS_VERSION ?>" />
 	<meta name="description" content="YOURLS &raquo; Your Own URL Shortener' | <?php yourls_site_url(); ?>" />
-	<meta name="referrer" content="always" />
 	<?php yourls_do_action('html_head_meta', $context); ?>
 	<link rel="shortcut icon" href="<?php yourls_favicon(); ?>" />
 	<script src="<?php yourls_site_url(); ?>/js/jquery-2.2.4.min.js?v=<?php echo YOURLS_VERSION; ?>" type="text/javascript"></script>


### PR DESCRIPTION
It's not clear why this tag was added, and it's even less clear what benefit there would be to keeping it. Its only real function seems to be leaking YOURLS' admin panel location (see #2432), which is not desirable.

A hook (or hooks) will likely be added to let plugins control referrer behavior, by adding the relevant HTTP header(s) and/or meta tag(s). (Separate PR, probably, because exactly what to do is still being defined.)