### PR TITLE
Replace unsafe dynamic $_SERVER['SERVER_NAME'] by safer YOURLS_SITE constant in login redirect

### DIFF
--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -80,7 +80,12 @@ function yourls_is_valid_user() {
 			
 			// Login form : redirect to requested URL to avoid re-submitting the login form on page reload
 			if( isset( $_REQUEST['username'] ) && isset( $_REQUEST['password'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
-				$url = yourls_match_current_protocol(yourls_sanitize_url(sprintf("%s%s", $_SERVER['SERVER_NAME'], $_SERVER['REQUEST_URI'])));
+				$yourls_url = parse_url( YOURLS_SITE );
+				unset($yourls_url['path']);
+				unset($yourls_url['query']);
+				unset($yourls_url['fragment']);
+				$redirect_url = yourls_unparse_url($yourls_url);
+				$url = yourls_match_current_protocol(yourls_sanitize_url(sprintf("%s%s", $redirect_url, $_SERVER['REQUEST_URI'])));
 				yourls_redirect( yourls_sanitize_url_safe($url) );
 			}
 		}

--- a/includes/functions-formatting.php
+++ b/includes/functions-formatting.php
@@ -718,3 +718,24 @@ function yourls_make_bookmarklet( $code ) {
     $book = new \Ozh\Bookmarkletgen\Bookmarkletgen;
     return $book->crunch( $code );
 }
+
+/**
+ * Converts an array parsed URL back to string
+ * See http://php.net/manual/fr/function.parse-url.php#106731
+ *
+ * @since 1.7.3
+ * @param  array $parsed_url    Parsed URL as array
+ * @return string               URL
+ */
+function yourls_unparse_url($parsed_url) {
+    $scheme = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+    $host = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+    $port = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
+    $user = isset($parsed_url['user']) ? $parsed_url['user'] : '';
+    $pass = isset($parsed_url['pass']) ? ':' . $parsed_url['pass'] : '';
+    $pass = ($user || $pass) ? "$pass@" : '';
+    $path = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+    $query = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+    $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+    return "$scheme$user$pass$host$port$path$query$fragment";
+}


### PR DESCRIPTION
1. Issue when webserver serving YOURLS is set with default/empty SERVER_NAME (e.g. _ in nginx) and server name is set by reverse proxy in front.
2. Security issue with some overridable values : https://expressionengine.com/blog/http-host-and-server-name-security-issues
3. Using defined constant is safer
4. Handles scheme, port and in URL username & password