### PR TITLE
Use HTTPS to get favicon from google service

### DIFF
--- a/includes/functions-infos.php
+++ b/includes/functions-infos.php
@@ -241,7 +241,7 @@ function yourls_get_domain( $url, $include_scheme = false ) {
  *
  */
 function yourls_get_favicon_url( $url ) {
-	return yourls_match_current_protocol( 'http://www.google.com/s2/favicons?domain=' . yourls_get_domain( $url, false ) );
+	return yourls_match_current_protocol( 'https://www.google.com/s2/favicons?domain=' . yourls_get_domain( $url, false ) );
 }
 
 /**


### PR DESCRIPTION
Using http will break https installs, as browsers will report a "mixed sources" issue and mark the whole page as unsecure.
Google provides the favicon service on http as well as on https, so it can be easily switched over to the https version.