### PR TITLE
Fix grammar and typo in readme.html

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -602,7 +602,7 @@ echo $data->longurl;</tt></pre>
 			<h3 id="limitations">Limitations</h3>
 			<ul>
 				<li>Maximum length of custom keyword is <strong>200 characters</strong></li>
-				<li>That makes about <strong>8 sexdecillions of centillions</strong> of available URLs (<a href="http://en.wikipedia.org/wiki/Names_of_large_numbers">seriously</a>. That's a 355 digits number). </li>
+				<li>That makes about <strong>8 sexdecillions of centillions</strong> of available URLs (<a href="http://en.wikipedia.org/wiki/Names_of_large_numbers">seriously</a>. That's a 355-digit number). </li>
 			</ul>
 
 			<h3 id="base3662">Difference Between Base 36 And Base 62 Encoding</h3>
@@ -733,7 +733,7 @@ echo $data->longurl;</tt></pre>
 
 			</ul>
 
-			<h2>YOURLS works with your favorite sofware or device</h2>
+			<h2>YOURLS works with your favorite software or device</h2>
 			<ul>
 				<li id="tweetie2"><a href="http://www.eugenegordin.com/etc/how-to-use-your-custom-yourls-shortener-with-tweetie-2.html">Tweetie 2</a><br/>
 				How to set up Tweetie2 so it uses your own service</li>


### PR DESCRIPTION
The current readme.html contains at least two typing mistakes:
- "355 digits number" should be "355-digit number".
- "sofware" should be "software".

Pulling this request fixes them.