### PR TITLE
Fix Type Juggling Bypass in Auth Functions

### DIFF
--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -133,7 +133,7 @@ function yourls_check_password_hash( $user, $submitted_password ) {
 		return( $yourls_user_passwords[ $user ] == 'md5:'.$salt.':'.md5( $salt . $submitted_password ) );
 	} else {
 		// Password stored in clear text
-		return( $yourls_user_passwords[ $user ] == $submitted_password );
+		return( $yourls_user_passwords[ $user ] === $submitted_password );
 	}
 }
 
@@ -297,7 +297,7 @@ function yourls_has_phpass_password( $user ) {
 function yourls_check_auth_cookie() {
 	global $yourls_user_passwords;
 	foreach( $yourls_user_passwords as $valid_user => $valid_password ) {
-		if ( yourls_salt( $valid_user ) == $_COOKIE[ yourls_cookie_name() ] ) {
+		if ( yourls_salt( $valid_user ) === $_COOKIE[ yourls_cookie_name() ] ) {
 			yourls_set_user( $valid_user );
 			return true;
 		}
@@ -326,9 +326,9 @@ function yourls_check_signature_timestamp() {
 	foreach( $yourls_user_passwords as $valid_user => $valid_password ) {
 		if (
 			(
-				md5( $_REQUEST['timestamp'].yourls_auth_signature( $valid_user ) ) == $_REQUEST['signature']
+				md5( $_REQUEST['timestamp'].yourls_auth_signature( $valid_user ) ) === $_REQUEST['signature']
 				or
-				md5( yourls_auth_signature( $valid_user ).$_REQUEST['timestamp'] ) == $_REQUEST['signature']
+				md5( yourls_auth_signature( $valid_user ).$_REQUEST['timestamp'] ) === $_REQUEST['signature']
 			)
 			&&
 			yourls_check_timestamp( $_REQUEST['timestamp'] )
@@ -355,7 +355,7 @@ function yourls_check_signature() {
 	// Check signature against all possible users
     global $yourls_user_passwords;
 	foreach( $yourls_user_passwords as $valid_user => $valid_password ) {
-		if ( yourls_auth_signature( $valid_user ) == $_REQUEST['signature'] ) {
+		if ( yourls_auth_signature( $valid_user ) === $_REQUEST['signature'] ) {
 			yourls_set_user( $valid_user );
 			return true;
 		}


### PR DESCRIPTION
The auth functions are vulnerable to Type Jugging attacks. Non strict comparisions can be used by an attacker to bypass auth and gain access to the admin page and API.

If PHP decides that both operands looks like numbers, it will convert both an perform numeric comparision. Ex: "0e348324" == "0e99" is true

This commit fixes 4 vulnerabilities:
- If an user password is saved as plaintext and looks like a number, for example, "0e23", an attacker can bypass login by submitting an input that looks like a number, "0e99".
- If an user cookie looks like a number, for example "0e210903587487700652447287594086", an attacker can bypass login by sending a cookie that also looks like a number, "0e32".
- If an user signature looks like a number, for example, "0e344332", an attacker can bypass API auth by sending a signature that also looks like a number, "0e84"

At last, the time limited token functionality can be abused to gain unauthorised access to the API without any requisite. Again, a type juggling attack is posible, but this time the attacker controls the result of the MD5, so thousands of requests can be made till the resultand hash takes the form of a number. We can bypass the YOURLS_NONCE_LIFE by introducing decimals in the timestamp, making the attack viable.

References:
[https://www.owasp.org/images/6/6b/PHPMagicTricks-TypeJuggling.pdf](https://www.owasp.org/images/6/6b/PHPMagicTricks-TypeJuggling.pdf)