### PR TITLE
Add jsonp parameter in API as a fallback to match documentation

### DIFF
--- a/yourls-api.php
+++ b/yourls-api.php
@@ -43,6 +43,8 @@ if ( false === $return ) {
 
 if( isset( $_REQUEST['callback'] ) )
 	$return['callback'] = $_REQUEST['callback'];
+elseif ( isset( $_REQUEST['jsonp'] ) )
+    $return['callback'] = $_REQUEST['jsonp'];
 
 $format = ( isset( $_REQUEST['format'] ) ? $_REQUEST['format'] : 'xml' );
 

--- a/yourls-api.php
+++ b/yourls-api.php
@@ -44,7 +44,7 @@ if ( false === $return ) {
 if( isset( $_REQUEST['callback'] ) )
 	$return['callback'] = $_REQUEST['callback'];
 elseif ( isset( $_REQUEST['jsonp'] ) )
-    $return['callback'] = $_REQUEST['jsonp'];
+	$return['callback'] = $_REQUEST['jsonp'];
 
 $format = ( isset( $_REQUEST['format'] ) ? $_REQUEST['format'] : 'xml' );
 


### PR DESCRIPTION
Issue #2566 was recently opened, reporting that the API documentation does not match the actual codebase. In an effort to standardise the request parameter required to support JSONP functionality, we've decided to remain backwards compatible while adding the `jsonp` parameter too, in order to make the [API documentation](https://api.yourls.org/doc) correct.

If you need anything else, just shout :smile: 