### PR TITLE
Trim overlong client information (HTTP referrer and user-agent)

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -888,8 +888,8 @@ function yourls_log_redirect( $keyword ) {
     $binds = array(
         'now' => date( 'Y-m-d H:i:s' ),
         'keyword'  => yourls_sanitize_string($keyword),
-        'referrer' => isset($_SERVER['HTTP_REFERER']) ? yourls_sanitize_url_safe($_SERVER['HTTP_REFERER']) : 'direct',
-        'ua'       => yourls_get_user_agent(),
+        'referrer' => isset($_SERVER['HTTP_REFERER']) ? yourls_sanitize_url_safe(substr($_SERVER['HTTP_REFERER'], 0, 200)) : 'direct',
+        'ua'       => substr(yourls_get_user_agent(), 0, 255),
         'ip'       => $ip,
         'location' => yourls_geo_ip_to_countrycode($ip),
     );


### PR DESCRIPTION
When following links from very long URLs (for instance, from mailing lists or newsletters), overlong client information fails to INSERT into the database because of the table's field lengths.
These two very simple changes trim overlong strings (maximum length as indicated in `includes\functions-install.php`).