### PR TITLE
Modified yourls_get_request() to strip standard ports from HOST header

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1976,6 +1976,8 @@ function yourls_get_request($yourls_site = false, $uri = false) {
     }
     if (false === $uri) {
         $uri = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        //remove standard ports from $uri in case the HOST header is set to include them since they will never be in $yourls_site
+        $uri = str_replace( array( ':80', ':443'), '', $uri);
     }
 
     // Even though the config sample states YOURLS_SITE should be set without trailing slash...

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1976,7 +1976,8 @@ function yourls_get_request($yourls_site = false, $uri = false) {
     }
     if (false === $uri) {
         $uri = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-        //remove standard ports from $uri in case the HOST header is set to include them since they will never be in $yourls_site
+        // Remove standard ports from $uri in case the HOST header is set to include them since they will never be in $yourls_site
+        // See #2613
         $uri = str_replace( array( ':80', ':443'), '', $uri);
     }
 


### PR DESCRIPTION
This adds support for HOST headers that always include port #s (even on standard ports 80/443 which will never appear in the YOURLS_SITE url).

This is in reference to #2611 