### PR TITLE
Windows / Linux htaccess test consistency

### DIFF
--- a/tests/tests/install/htaccess.php
+++ b/tests/tests/install/htaccess.php
@@ -43,12 +43,12 @@ class Install_htaccess_Tests extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_htaccess( $server, $is_apache, $file ) {
         $_SERVER['SERVER_SOFTWARE'] = $server;
-        
+
         $this->assertSame( $is_apache, yourls_is_apache() );
-        
+
         if( file_exists( YOURLS_ABSPATH . '/' . $file ) )
             @unlink( YOURLS_ABSPATH . '/' . $file );
-        
+
 		$this->assertTrue( yourls_create_htaccess() );
 		$this->assertFileExists( YOURLS_ABSPATH . '/' . $file );
 	}
@@ -75,28 +75,34 @@ class Install_htaccess_Tests extends PHPUnit_Framework_TestCase {
 	public function test_htaccess_content( $filename ) {
         $newfile  = str_replace( 'original_', 'test_', $filename );
         $expected = str_replace( 'original_', 'expected_', $filename );
-        
+
         $newfile  = YOURLS_TESTDATA_DIR . '/htaccess/' . $newfile;
         $filename = YOURLS_TESTDATA_DIR . '/htaccess/' . $filename;
         $expected = YOURLS_TESTDATA_DIR . '/htaccess/' . $expected;
-        
+
         // If file exist, copy it (if file doesn't exist, it's because we're creating from scratch)
         if( file_exists( $filename ) ) {
             if ( !copy( $filename, $newfile ) ) {
                 $this->markTestSkipped( "Cannot copy file $filename" );
             }
         }
-        
+
         $marker = 'YOURLS';
-        $content = array( 
+        $content = array(
             'This is a test',
             'Hello World',
             '1,2... 1,2...',
         );
-        
+
+        // check we can create the htaccess
         $this->assertTrue( yourls_insert_with_markers( $newfile, $marker, $content ) );
-        $this->assertFileEquals( $expected, $newfile );
-        @unlink( $newfile );
+
+        // check it is correctly create. First, remove line endings so tests are consistent between Windows and Linux
+        // For this reason, we're not using $this->assertFileEquals()
+        $exp = array_map( function($line) {return str_replace(array("\r", "\n"), '', $line);}, file($expected));
+        $new = array_map( function($line) {return str_replace(array("\r", "\n"), '', $line);}, file($newfile));
+        $this->assertSame($exp, $new);
+        unlink( $newfile );
 	}
 
 }


### PR DESCRIPTION
Unit tests fail on Windows while passing on Linux because of line ending comparisons. Fix.

```
There were 6 failures:

1) Install_htaccess_Tests::test_htaccess_content with data set #0 ('original_nofile.txt')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'\r\n
-\r\n
-# BEGIN YOURLS\r\n
-This is a test\r\n
-Hello World\r\n
-1,2... 1,2...\r\n
-# END YOURLS\r\n
-\r\n
+'\n
+\n
+# BEGIN YOURLS\n
+This is a test\n
+Hello World\n
+1,2... 1,2...\n
+# END YOURLS\n
+\n
 '
```