### PR TITLE
Allow 255 chars for the user agent, as this is the column size in the DB

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -198,7 +198,7 @@ function yourls_get_user_agent() {
 	$ua = strip_tags( html_entity_decode( $_SERVER['HTTP_USER_AGENT'] ));
 	$ua = preg_replace('![^0-9a-zA-Z\':., /{}\(\)\[\]\+@&\!\?;_\-=~\*\#]!', '', $ua );
 
-	return yourls_apply_filter( 'get_user_agent', substr( $ua, 0, 254 ) );
+	return yourls_apply_filter( 'get_user_agent', substr( $ua, 0, 255 ) );
 }
 
 /**


### PR DESCRIPTION
Allow 255 chars for the user agent, as this is the column size in the DB. The limit of 255 is also enforced in the calling function [yourls_log_redirect](https://github.com/YOURLS/YOURLS/blob/c6d9710c6284c865835659d5a5a70bd4484a1089/includes/functions.php#L405).