### PR TITLE
New plugin hook for manipulating the HTTP referrer

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -207,10 +207,7 @@ function yourls_get_user_agent() {
  * @return string               HTTP Referrer or 'direct' if no refferer was provided
  */
 function yourls_get_referrer() {
-    if ( !isset( $_SERVER['HTTP_REFERER'] ) )
-        return 'direct';
-
-    $referrer = yourls_sanitize_url_safe( $_SERVER['HTTP_REFERER'] );
+    $referrer = isset( $_SERVER['HTTP_REFERER'] ) ? yourls_sanitize_url_safe( $_SERVER['HTTP_REFERER'] ) : 'direct';
 
     return yourls_apply_filter( 'get_referrer', substr( $referrer, 0, 200 ) );
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -202,6 +202,20 @@ function yourls_get_user_agent() {
 }
 
 /**
+ * Returns the sanitized referrer submitted by the browser.
+ *
+ * @return string               HTTP Referrer or 'direct' if no refferer was provided
+ */
+function yourls_get_referrer() {
+    if ( !isset( $_SERVER['HTTP_REFERER'] ) )
+        return 'direct';
+
+    $referrer = yourls_sanitize_url_safe( $_SERVER['HTTP_REFERER'] );
+
+    return yourls_apply_filter( 'get_referrer', substr( $referrer, 0, 200 ) );
+}
+
+/**
  * Redirect to another page
  *
  * YOURLS redirection, either to internal or external URLs. If headers have not been sent, redirection
@@ -401,7 +415,7 @@ function yourls_log_redirect( $keyword ) {
     $binds = array(
         'now' => date( 'Y-m-d H:i:s' ),
         'keyword'  => yourls_sanitize_string($keyword),
-        'referrer' => isset($_SERVER['HTTP_REFERER']) ? yourls_sanitize_url_safe(substr($_SERVER['HTTP_REFERER'], 0, 200)) : 'direct',
+        'referrer' => substr( yourls_get_referrer(), 0, 200 ),
         'ua'       => substr(yourls_get_user_agent(), 0, 255),
         'ip'       => $ip,
         'location' => yourls_geo_ip_to_countrycode($ip),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -192,19 +192,20 @@ function yourls_get_num_queries() {
  *
  */
 function yourls_get_user_agent() {
-	if ( !isset( $_SERVER['HTTP_USER_AGENT'] ) )
-		return '-';
+    $ua = '-';
 
-	$ua = strip_tags( html_entity_decode( $_SERVER['HTTP_USER_AGENT'] ));
-	$ua = preg_replace('![^0-9a-zA-Z\':., /{}\(\)\[\]\+@&\!\?;_\-=~\*\#]!', '', $ua );
+    if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+        $ua = strip_tags( html_entity_decode( $_SERVER['HTTP_USER_AGENT'] ));
+        $ua = preg_replace('![^0-9a-zA-Z\':., /{}\(\)\[\]\+@&\!\?;_\-=~\*\#]!', '', $ua );
+    }
 
-	return yourls_apply_filter( 'get_user_agent', substr( $ua, 0, 255 ) );
+    return yourls_apply_filter( 'get_user_agent', substr( $ua, 0, 255 ) );
 }
 
 /**
  * Returns the sanitized referrer submitted by the browser.
  *
- * @return string               HTTP Referrer or 'direct' if no refferer was provided
+ * @return string               HTTP Referrer or 'direct' if no referrer was provided
  */
 function yourls_get_referrer() {
     $referrer = isset( $_SERVER['HTTP_REFERER'] ) ? yourls_sanitize_url_safe( $_SERVER['HTTP_REFERER'] ) : 'direct';

--- a/readme.html
+++ b/readme.html
@@ -569,7 +569,7 @@ echo $data->longurl;</tt></pre>
 			<ul>
 				<li>Unless you plan on making it public and as popular as bit.ly, any shared hosting will be fine. Ozh runs all his YOURLS instance on <a href="https://yourls.org/dreamhost">Dreamhost</a> and it works just great.</li>
 				<li><a href="http://domai.nr/">Domainr</a> is a fun search tool that might inspire and help you</li>
-				<li>Aim for exotic top level domains (.in, .im, .li ...), they're often cheap and a lot are still available. <a href="https://www.gandi.net/domain/buy/search/">Gandi</a> is a pretty comprehensive registrar, for instance.</li>
+				<li>Aim for exotic top level domains (.in, .im, .li ...), they're often cheap and a lot are still available. <a href="http://yourls.org/gandi">Gandi</a> is a pretty comprehensive registrar, for instance.</li>
 			</ul>
 
 			<a class="anch" href="#FAQ;htaccess"><span>&#10148;</span><h3 id="htaccess">YOURLS needs its own .htaccess</h3></a>


### PR DESCRIPTION
This allows plugins to change the HTTP referrer.

The code adds a new function, ```yourls_get_referrer``` which is called by ```yourls_log_redirect```. A new hook is added, ```get_referrer```, so that plugins can change the referrer information.