### PR TITLE
Return png logo height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -41,7 +41,7 @@ h1 a:hover{text-decoration:none;}
 h1 a:hover span{text-decoration:underline;color:#88c0eb}
 #yourls-logo {
     border:0px;
-    width:300px;
+    width:200px;
 }
 ul#admin_menu {
 	min-height:100px;


### PR DESCRIPTION
Hello!

After https://github.com/YOURLS/YOURLS/pull/2649 clear install looks worse.

![Снимок экрана от 2020-08-12 18-11-45](https://user-images.githubusercontent.com/1775220/90019462-e235ca00-dcc7-11ea-92c5-ea96df99ce73.png)

I think, previous logo height (201px) looks better.

![Снимок экрана от 2020-08-12 18-17-39](https://user-images.githubusercontent.com/1775220/90019708-3b056280-dcc8-11ea-9b41-14a1b64fa470.png)
