### PR TITLE
Allow changing the "/admin/" part of the URI

### DIFF
--- a/includes/functions-links.php
+++ b/includes/functions-links.php
@@ -157,7 +157,8 @@ function yourls_admin_url( $page = '' ) {
     } else {
         $yourls_admin_dir = "admin";
     } 
-    $admin = yourls_get_yourls_site() . '/' . $yourls_admin_dir . '/' . $page;    if( yourls_is_ssl() or yourls_needs_ssl() ) {
+    $admin = yourls_get_yourls_site() . '/' . $yourls_admin_dir . '/' . $page;
+    if( yourls_is_ssl() or yourls_needs_ssl() ) {
         $admin = yourls_set_url_scheme( $admin, 'https' );
     }
     return yourls_apply_filter( 'admin_url', $admin, $page );

--- a/includes/functions-links.php
+++ b/includes/functions-links.php
@@ -152,8 +152,12 @@ function yourls_statlink( $keyword = '' ) {
  *
  */
 function yourls_admin_url( $page = '' ) {
-    $admin = yourls_get_yourls_site() . '/admin/' . $page;
-    if( yourls_is_ssl() or yourls_needs_ssl() ) {
+    if ( defined( 'YOURLS_ADMIN_DIR' ) ) {
+        $yourls_admin_dir = YOURLS_ADMIN_DIR;
+    } else {
+        $yourls_admin_dir = "admin";
+    } 
+    $admin = yourls_get_yourls_site() . '/' . $yourls_admin_dir . '/' . $page;    if( yourls_is_ssl() or yourls_needs_ssl() ) {
         $admin = yourls_set_url_scheme( $admin, 'https' );
     }
     return yourls_apply_filter( 'admin_url', $admin, $page );


### PR DESCRIPTION
Like how WP and many other services allow changing the admin URL, allow the admin directory name to be changed to make it just a little harder for a bot to do a brute force attack at the login area.

Overriding the default "/admin/" is done through the config.php page like other related settings:

```
define( 'YOURLS_ADMIN_DIR', 'MyAdm1nistrationZ0ne' );
```