### PR TITLE
The mac client is deprecated

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -701,9 +701,6 @@ echo $data->longurl;</tt></pre>
 				<li id="twitterfeed"><a href="http://blog.yourls.org/2011/09/how-to-use-twitterfeed-with-your-custom-yourls-url-shortener/">Twitterfeed</a><br/>
 				Use Twitterfeed with YOURLS</li>
 
-				<li id="mac"><a href="http://timi.im/app/">Mac Client</a><br/>
-				Simple app to have a global keyboard shortcut send a link to YOURLS</li>
-
 				<li id="android">Android: <a href="https://play.google.com/store/apps/details?id=de.mateware.ayourls">aYourls</a>, <a href="https://play.google.com/store/apps/details?id=com.mndroid.apps.urly">URLy</a> and <a href="https://play.google.com/store/apps/details?id=de.keineantwort.android.urlshortener">URL Shortener</a><br/>
 				Android apps that plays nice with YOURLS</li>
 


### PR DESCRIPTION
The mac client is deprecated and the link is redirecting to other website (http://timi.im/app/) which looks malicious.