### PR TITLE
Sanitize plugin file header before display

### DIFF
--- a/includes/functions-plugins.php
+++ b/includes/functions-plugins.php
@@ -421,7 +421,7 @@ function yourls_get_plugin_data( $file ) {
             continue;
         }
 
-        $plugin_data[ trim($matches[3]) ] = trim($matches[4]);
+        $plugin_data[ trim($matches[3]) ] = yourls_esc_html(trim($matches[4]));
     }
 
     return $plugin_data;


### PR DESCRIPTION
Avoid improbable case such as:

```php
/**
 * Plugin Name: anything"><img src=x onerror=prompt("name")>
 * Plugin URI: anything"><img src=x onerror=prompt("")>
 * Description: anything"><img src=x onerror=prompt("desc")>
 * Version: anything"><img src=x onerror=prompt('version')>
 * Author: anything"><img src=x onerror=prompt('author')>
 * Author URI: anything"><img src=x onerror=prompt("desc")>
 */
```