### PR TITLE
Replace `call_user_func()` with variable functions

### DIFF
--- a/includes/functions-plugins.php
+++ b/includes/functions-plugins.php
@@ -149,7 +149,7 @@ function yourls_apply_filter( $hook, $value = '' ) {
     reset( $yourls_filters[ $hook ] );
     do {
         foreach ( (array)current( $yourls_filters[ $hook ] ) as $the_ ) {
-            if ( !is_null( $the_[ 'function' ] ) ) {
+            if ( !is_null($the_[ 'function' ]) ) {
                 $args[ 1 ] = $value;
                 $count = $the_[ 'accepted_args' ];
                 if ( is_null( $count ) ) {
@@ -628,13 +628,19 @@ function yourls_plugin_admin_page( $plugin_page ) {
         yourls_die( yourls__( 'This page does not exist. Maybe a plugin you thought was activated is inactive?' ), yourls__( 'Invalid link' ) );
     }
 
+    // Check the plugin page function is actually callable
+    $page_function = $pages[ $plugin_page ][ 'function' ];
+    if (!is_callable($page_function)) {
+        yourls_die( yourls__( 'This page cannot be displayed because the displaying function is not callable.' ), yourls__( 'Invalid code' ) );
+    }
+
     // Draw the page itself
     yourls_do_action( 'load-'.$plugin_page );
     yourls_html_head( 'plugin_page_'.$plugin_page, $pages[ $plugin_page ][ 'title' ] );
     yourls_html_logo();
     yourls_html_menu();
 
-    call_user_func( $pages[ $plugin_page ][ 'function' ] );
+    $page_function( );
 
     yourls_html_footer();
 }

--- a/tests/tests/api/funcs.php
+++ b/tests/tests/api/funcs.php
@@ -28,7 +28,10 @@ class API_Func_Tests extends PHPUnit_Framework_TestCase {
     public function test_api_actions( $action, $alias ) {
         $action = $alias ? $alias : $action;
 
-        $this->assertTrue( is_array( call_user_func( 'yourls_api_action_' . $action ) ) );
+        $function = 'yourls_api_action_' . $action;
+
+        $this->assertTrue( is_callable( $function ) );
+        $this->assertTrue( is_array( $function() ) );
     }
 
 }

--- a/tests/tests/plugins/misc.php
+++ b/tests/tests/plugins/misc.php
@@ -165,4 +165,26 @@ class Plugin_Misc_Tests extends PHPUnit_Framework_TestCase {
         $this->assertSame( 1, yourls_did_action( $action ) );
     }
 
+    /**
+    * Simulate a valid plugin admin page but with a drawing function that is not callable
+    *
+    * @expectedException Exception
+    * @since 0.1
+    */
+    public function test_plugin_admin_page_not_callable() {
+        $plugin = rand_str();
+        $title  = rand_str();
+        $action = rand_str();
+        $func   = rand_str();
+        yourls_register_plugin_page( $plugin, $title, $func );
+
+        $this->assertSame( 0, yourls_did_action( 'load-' . $plugin ) );
+
+        // intercept yourls_die() before it actually dies
+        yourls_add_action( 'pre_yourls_die', function() { throw new Exception( 'I have died' ); } );
+
+        // This should trigger yourls_die()
+        yourls_plugin_admin_page( $plugin );
+    }
+
 }


### PR DESCRIPTION
Backstory: #2714 

Idea:
```php
// before : 
call_user_func( $function1 );
call_user_func( $function2, $param );
// after :
$function1();
$function2( $param );
```

Also, add checks for `is_callable()` where relevant, and update tests accordingly.