### PR TITLE
Add WhatsApp and Telegram Protocols

### DIFF
--- a/includes/functions-kses.php
+++ b/includes/functions-kses.php
@@ -544,7 +544,7 @@ function yourls_kses_allowed_protocols() {
 		'irc://', 'ircs://', 'mumble://', 
 		'callto:', 'skype:', 'sip:',
 		'teamspeak://', 'tel:', 'ventrilo://', 'xfire:', 
-		'ymsgr:', 
+		'ymsgr:', 'tg://', 'whatsapp://'
 
 		// Misc
 		'steam:', 'steam://',


### PR DESCRIPTION
Hey :)

I don't know if there are any requirements for new protocols to be added, but I reckon that both WhatsApp and Telegram are popular enough to have theirs added and also the change was small enough for me not to ask in an issue first.

If you're hesitent to add new protocols, feel free to close. I'll just use a plugin, then.

Cheers,
Hinrich