### PR TITLE
Fix typo broken in #2781

### DIFF
--- a/includes/functions-kses.php
+++ b/includes/functions-kses.php
@@ -544,7 +544,7 @@ function yourls_kses_allowed_protocols() {
 		'irc://', 'ircs://', 'mumble://', 
 		'callto:', 'skype:', 'sip:',
 		'teamspeak://', 'tel:', 'ventrilo://', 'xfire:', 
-		'ymsgr:', 'tg://', 'whatsapp://'
+		'ymsgr:', 'tg://', 'whatsapp://',
 
 		// Misc
 		'steam:', 'steam://',


### PR DESCRIPTION
I'm a little frustrated that no one tested the #2781 change as it was a clear PHP error...

> PHP message: PHP Parse error: syntax error, unexpected ''steam:'' (T_CONSTANT_ENCAPSED_STRING), expecting ')' in /home/path/to//public_html/includes/functions-kses.php on line 550