### PR TITLE
Fix encoding when editing existing shortcut

### DIFF
--- a/includes/functions-shorturls.php
+++ b/includes/functions-shorturls.php
@@ -297,6 +297,7 @@ function yourls_edit_link( $url, $keyword, $newkeyword='', $title='' ) {
     $ydb = yourls_get_db();
 
     $table = YOURLS_DB_TABLE_URL;
+    $url = yourls_encodeURI( $url );
     $url = yourls_sanitize_url($url);
     $keyword = yourls_sanitize_keyword($keyword);
     $title = yourls_sanitize_title($title);


### PR DESCRIPTION
Previously URL encoded links are decoded before adding **New** shortcuts in `yourls_add_new_link()`.
This updates `yourls_edit_link()` to do the same for **Edits** of existing shortcut.