### PR TITLE
optional `$title` param in `yourls_table_add_row()` can't be optional

### DIFF
--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -519,8 +519,8 @@ RETURN;
  *
  * @return string HTML of the edit row
  */
-function yourls_table_add_row( $keyword, $url, $title = '', $ip, $clicks, $timestamp ) {
-    $keyword  = yourls_sanitize_keyword($keyword);
+function yourls_table_add_row( $keyword, $url, $title, $ip, $clicks, $timestamp ) {
+	$keyword  = yourls_sanitize_keyword($keyword);
 	$id       = yourls_string2htmlid( $keyword ); // used as HTML #id
 	$shorturl = yourls_link( $keyword );
 


### PR DESCRIPTION
PHP 8.0 deprecated optional parameters before required ones: https://php.watch/versions/8.0/deprecate-required-param-after-optional

All call sites in YOURLS already pass `$title` (because they have to), so there's no reason it needs to be an optional argument. This change resolves part of #2807.

Additionally, the first line of `yourls_table_add_row()` was indented with spaces instead of using s tab character like the rest of the file. This has been corrected as a bonus.