### PR TITLE
Prevent YOURLS from displaying encryption warning when password is provided via environment variables

### DIFF
--- a/includes/auth.php
+++ b/includes/auth.php
@@ -41,26 +41,23 @@ if ( isset( $_GET['dismiss'] ) && $_GET['dismiss'] == 'hasherror' ) {
 } else {
 
 	// Encrypt passwords that are clear text
-	if ( !defined( 'YOURLS_NO_HASH_PASSWORD' ) && yourls_has_cleartext_passwords() ) {
-		// Check if user is provided from environment variables, if true do not bother to encrypt passwords
-		if ( !yourls_check_user_from_env() ) {
-			$hash = yourls_hash_passwords_now( YOURLS_CONFIGFILE );
-			if ( $hash === true ) {
-				// Hashing succesful. Remove flag from DB if any.
-				if( yourls_get_option( 'defer_hashing_error' ) )
-					yourls_delete_option( 'defer_hashing_error' );
-			} else {
-				// It failed, display message for first time or if last time was a week ago
-				if ( time() > yourls_get_option( 'defer_hashing_error' ) or !yourls_get_option( 'defer_hashing_error' ) ) {
-					$message  = yourls_s( 'Could not auto-encrypt passwords. Error was: "%s".', $hash );
-					$message .= ' ';
-					$message .= yourls_s( '<a href="%s">Get help</a>.', 'http://yourls.org/userpassword' );
-					$message .= '</p><p>';
-					$message .= yourls_s( '<a href="%s">Click here</a> to dismiss this message for one week.', '?dismiss=hasherror' );
+	if ( yourls_maybe_hash_passwords() ) {
+        $hash = yourls_hash_passwords_now( YOURLS_CONFIGFILE );
+        if ( $hash === true ) {
+            // Hashing succesful. Remove flag from DB if any.
+            if( yourls_get_option( 'defer_hashing_error' ) )
+                yourls_delete_option( 'defer_hashing_error' );
+        } else {
+            // It failed, display message for first time or if last time was a week ago
+            if ( time() > yourls_get_option( 'defer_hashing_error' ) or !yourls_get_option( 'defer_hashing_error' ) ) {
+                $message  = yourls_s( 'Could not auto-encrypt passwords. Error was: "%s".', $hash );
+                $message .= ' ';
+                $message .= yourls_s( '<a href="%s">Get help</a>.', 'http://yourls.org/userpassword' );
+                $message .= '</p><p>';
+                $message .= yourls_s( '<a href="%s">Click here</a> to dismiss this message for one week.', '?dismiss=hasherror' );
 
-					yourls_add_notice( $message );
-				}
-			}
-		}
+                yourls_add_notice( $message );
+            }
+        }
 	}
 }

--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -640,8 +640,34 @@ function yourls_verify_nonce( $action, $nonce = false, $user = false, $return = 
 /**
  * Check if YOURLS_USER comes from environment variables
  *
+ * @since 1.8.2
+ * @return bool     true if YOURLS_USER and YOURLS_PASSWORD are defined as environment variables
  */
-function yourls_check_user_from_env() {
-	if ( getenv('YOURLS_USER') && getenv('YOURLS_PASSWORD') && count($yourls_user_passwords) == 1 ) return true;
-	return false;
+function yourls_is_user_from_env() {
+	return yourls_apply_filter('is_user_from_env', getenv('YOURLS_USER') && getenv('YOURLS_PASSWORD'));
+
+}
+
+/**
+ * Check if we should hash passwords in the config file
+ *
+ * By default, passwords are hashed. They are not if
+ *    - there is no password in clear text in the config file (ie everything is already hashed)
+ *    - the user defined constant YOURLS_NO_HASH_PASSWORD is true, see https://github.com/YOURLS/YOURLS/wiki/Username-Passwords#but-i-dont-want-to-encrypt-my-password-
+ *    - YOURLS_USER and YOURLS_PASSWORD are provided by the environment, not the config file
+ *
+ * @since 1.8.2
+ * @return bool
+ */
+function yourls_maybe_hash_passwords() {
+    $hash = true;
+
+    if ( !yourls_has_cleartext_passwords()
+         OR (defined('YOURLS_NO_HASH_PASSWORD') && YOURLS_NO_HASH_PASSWORD)
+         OR (yourls_is_user_from_env())
+    ) {
+        $hash = false;
+    }
+
+    return yourls_apply_filter('maybe_hash_password', $hash );
 }

--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -213,6 +213,8 @@ function yourls_hash_passwords_now( $config_file ) {
 		yourls_debug_log( 'Failed writing to ' . $config_file );
 		return 'could not write file';
 	}
+
+    yourls_debug_log('Successfully encrypted passwords in ' . basename($config_file));
 	return true;
 }
 

--- a/includes/functions-shorturls.php
+++ b/includes/functions-shorturls.php
@@ -301,8 +301,6 @@ function yourls_edit_link( $url, $keyword, $newkeyword='', $title='' ) {
     $keyword = yourls_sanitize_keyword($keyword);
     $title = yourls_sanitize_title($title);
     $newkeyword = yourls_sanitize_keyword($newkeyword, true);
-    $strip_url = stripslashes( $url );
-    $strip_title = stripslashes( $title );
 
     if(!$url OR !$newkeyword) {
         $return['status']  = 'fail';
@@ -334,12 +332,18 @@ function yourls_edit_link( $url, $keyword, $newkeyword='', $title='' ) {
             $binds = array('url' => $url, 'newkeyword' => $newkeyword, 'title' => $title, 'keyword' => $keyword);
             $update_url = $ydb->fetchAffected($sql, $binds);
         if( $update_url ) {
-            $return['url']     = array( 'keyword' => $newkeyword, 'shorturl' => yourls_link($newkeyword), 'url' => $strip_url, 'display_url' => yourls_trim_long_string( $strip_url ), 'title' => $strip_title, 'display_title' => yourls_trim_long_string( $strip_title ) );
+            $return['url']     = array( 'keyword'       => $newkeyword,
+                                        'shorturl'      => yourls_link($newkeyword),
+                                        'url'           => yourls_esc_url($url),
+                                        'display_url'   => yourls_esc_html(yourls_trim_long_string($url)),
+                                        'title'         => yourls_esc_attr($title),
+                                        'display_title' => yourls_esc_html(yourls_trim_long_string( $title ))
+                                );
             $return['status']  = 'success';
             $return['message'] = yourls__( 'Link updated in database' );
         } else {
             $return['status']  = 'fail';
-            $return['message'] = /* //translators: "Error updating http://someurl/ (Shorturl: http://sho.rt/blah)" */ yourls_s( 'Error updating %s (Short URL: %s)', yourls_trim_long_string( $strip_url ), $keyword ) ;
+            $return['message'] = /* //translators: "Error updating http://someurl/ (Shorturl: http://sho.rt/blah)" */ yourls_s( 'Error updating %s (Short URL: %s)', yourls_esc_html(yourls_trim_long_string($url)), $keyword ) ;
         }
 
     // Nope

--- a/tests/data/config/yourls-tests-config-ci.php
+++ b/tests/data/config/yourls-tests-config-ci.php
@@ -26,7 +26,6 @@ define('YOURLS_URL_CONVERT',  62);
 define('YOURLS_DB_PREFIX',  'yourls_');
 define('YOURLS_FLOOD_DELAY_SECONDS',  0);
 define('YOURLS_FLOOD_IP_WHITELIST',  '');
-define('YOURLS_NO_HASH_PASSWORD',  true); // prevents rewriting config.php with encrypted passwords
 define('YOURLS_LANG',  'fr_FR'); // locale of a sample translation file in the data dir
 define('YOURLS_DEBUG', true);
 

--- a/tests/data/config/yourls-tests-config-sample.php
+++ b/tests/data/config/yourls-tests-config-sample.php
@@ -28,7 +28,6 @@ define('YOURLS_URL_CONVERT',  62);
 define('YOURLS_DB_PREFIX',  'yourls_');
 define('YOURLS_FLOOD_DELAY_SECONDS',  0);
 define('YOURLS_FLOOD_IP_WHITELIST',  '');
-define('YOURLS_NO_HASH_PASSWORD',  true); // prevents rewriting config.php with encrypted passwords
 define('YOURLS_LANG',  'fr_FR'); // locale of a sample translation file in the data dir
 define('YOURLS_DEBUG', true);
 

--- a/tests/tests/auth/auth.php
+++ b/tests/tests/auth/auth.php
@@ -150,7 +150,7 @@ class Auth_Func_Tests extends PHPUnit\Framework\TestCase {
      */
     public function test_hash_passwords_now() {
         // If local: make a copy of user/config-sample.php to user/config-test.php in case tests not run on a clean install
-        // on Travis: just proceed with user/config-sample.php since there's always a `git clone` first
+        // on Github: just proceed with user/config-sample.php since there's always a `git clone` first
         if( yut_is_local() ) {
             if( !copy( YOURLS_USERDIR . '/config-sample.php', YOURLS_USERDIR . '/config-test.php' ) ) {
                 // Copy failed, we cannot run this test.
@@ -203,5 +203,59 @@ class Auth_Func_Tests extends PHPUnit\Framework\TestCase {
         exec( YOURLS_PHP_BIN . ' -l ' .  escapeshellarg( $config_file ), $output, $return );
         $this->assertEquals( 0, $return );
     }
+
+    /**
+     * Check that we hash passwords by default
+     */
+    public function test_maybe_hash_passwords_clear_passwords() {
+        global $yourls_user_passwords;
+        $copy = $yourls_user_passwords;
+
+        $yourls_user_passwords = [];
+        $yourls_user_passwords['ozh'] = 'ozh';
+
+        $this->assertTrue( yourls_maybe_hash_passwords() );
+
+        $yourls_user_passwords = $copy;
+    }
+
+    /**
+     * Check that we don't hash passwords in config file if there's nothing to hash
+     */
+    public function test_maybe_hash_passwords_no_clear_password() {
+        global $yourls_user_passwords;
+        $copy = $yourls_user_passwords;
+
+        $yourls_user_passwords = array();
+        $yourls_user_passwords['md5'] = $copy['md5'];
+
+        $this->assertFalse( yourls_maybe_hash_passwords() );
+
+        $yourls_user_passwords = $copy;
+    }
+
+    /**
+     * Check that we don't hash passwords in config file if user explicitly doesn't want it
+     *
+     * Actually we're not testing this :-(
+     */
+    public function zz_test_maybe_hash_passwords_YOURLS_NO_HASH_PASSWORD() {
+        // we're not testing anything because it currently relies on a defined constant
+    }
+
+    /**
+     * Check that we don't hash passwords in config file if USER/PWD provided by env
+     */
+    public function test_maybe_hash_passwords_via_env() {
+        putenv('YOURLS_USER=ozh');
+        putenv('YOURLS_PASSWORD=ozh');
+
+        $this->assertFalse( yourls_maybe_hash_passwords() );
+
+        putenv('YOURLS_USER');
+        putenv('YOURLS_PASSWORD');
+    }
+
+
 
 }

--- a/tests/tests/shorturl/shorturl.php
+++ b/tests/tests/shorturl/shorturl.php
@@ -40,6 +40,9 @@ class ShortURL_Tests extends PHPUnit\Framework\TestCase {
 
         $fail = yourls_add_new_link( $url, $keyword, $title );
         $this->assertEquals( 'fail', $fail['status'] );
+
+        $fail = yourls_add_new_link( $url, rand_str(), rand_str() );
+        $this->assertEquals( 'fail', $fail['status'] );
         $this->assertEquals( 'error:url', $fail['code'] );
 
         $fail = yourls_add_new_link( 'http://' . rand_str(), $keyword, $title );


### PR DESCRIPTION
Perhaps a fix for #3038.
Maybe, just a quick, dirty solution (first that came in my mind, feel free to propose / do something else).

EDIT: to be clear, I have not tested this yet, I based my PR on top of documentation, code comments and digging around a little. Using Træfik+Docker in production w/ the official image, I have really no easy way to test this out by myself. Perhaps a unit test could do the work for us.