### PR TITLE
Minor security improvements #2

### DIFF
--- a/includes/functions-shorturls.php
+++ b/includes/functions-shorturls.php
@@ -301,8 +301,6 @@ function yourls_edit_link( $url, $keyword, $newkeyword='', $title='' ) {
     $keyword = yourls_sanitize_keyword($keyword);
     $title = yourls_sanitize_title($title);
     $newkeyword = yourls_sanitize_keyword($newkeyword, true);
-    $strip_url = stripslashes( $url );
-    $strip_title = stripslashes( $title );
 
     if(!$url OR !$newkeyword) {
         $return['status']  = 'fail';
@@ -337,15 +335,15 @@ function yourls_edit_link( $url, $keyword, $newkeyword='', $title='' ) {
             $return['url']     = array( 'keyword'       => $newkeyword,
                                         'shorturl'      => yourls_link($newkeyword),
                                         'url'           => yourls_esc_url($url),
-                                        'display_url'   => yourls_esc_html(yourls_trim_long_string($strip_url)),
-                                        'title'         => yourls_esc_attr($strip_title),
-                                        'display_title' => yourls_esc_html(yourls_trim_long_string( $strip_title ))
+                                        'display_url'   => yourls_esc_html(yourls_trim_long_string($url)),
+                                        'title'         => yourls_esc_attr($title),
+                                        'display_title' => yourls_esc_html(yourls_trim_long_string( $title ))
                                 );
             $return['status']  = 'success';
             $return['message'] = yourls__( 'Link updated in database' );
         } else {
             $return['status']  = 'fail';
-            $return['message'] = /* //translators: "Error updating http://someurl/ (Shorturl: http://sho.rt/blah)" */ yourls_s( 'Error updating %s (Short URL: %s)', yourls_trim_long_string( $strip_url ), $keyword ) ;
+            $return['message'] = /* //translators: "Error updating http://someurl/ (Shorturl: http://sho.rt/blah)" */ yourls_s( 'Error updating %s (Short URL: %s)', yourls_esc_html(yourls_trim_long_string($url)), $keyword ) ;
         }
 
     // Nope

--- a/includes/functions-shorturls.php
+++ b/includes/functions-shorturls.php
@@ -334,7 +334,13 @@ function yourls_edit_link( $url, $keyword, $newkeyword='', $title='' ) {
             $binds = array('url' => $url, 'newkeyword' => $newkeyword, 'title' => $title, 'keyword' => $keyword);
             $update_url = $ydb->fetchAffected($sql, $binds);
         if( $update_url ) {
-            $return['url']     = array( 'keyword' => $newkeyword, 'shorturl' => yourls_link($newkeyword), 'url' => $strip_url, 'display_url' => yourls_trim_long_string( $strip_url ), 'title' => $strip_title, 'display_title' => yourls_trim_long_string( $strip_title ) );
+            $return['url']     = array( 'keyword'       => $newkeyword,
+                                        'shorturl'      => yourls_link($newkeyword),
+                                        'url'           => yourls_esc_url($url),
+                                        'display_url'   => yourls_esc_html(yourls_trim_long_string($strip_url)),
+                                        'title'         => yourls_esc_attr($strip_title),
+                                        'display_title' => yourls_esc_html(yourls_trim_long_string( $strip_title ))
+                                );
             $return['status']  = 'success';
             $return['message'] = yourls__( 'Link updated in database' );
         } else {

--- a/tests/tests/shorturl/shorturl.php
+++ b/tests/tests/shorturl/shorturl.php
@@ -40,6 +40,9 @@ class ShortURL_Tests extends PHPUnit\Framework\TestCase {
 
         $fail = yourls_add_new_link( $url, $keyword, $title );
         $this->assertEquals( 'fail', $fail['status'] );
+
+        $fail = yourls_add_new_link( $url, rand_str(), rand_str() );
+        $this->assertEquals( 'fail', $fail['status'] );
         $this->assertEquals( 'error:url', $fail['code'] );
 
         $fail = yourls_add_new_link( 'http://' . rand_str(), $keyword, $title );


### PR DESCRIPTION
Another minor security issue has been reported : up to 1.8.1 it is possible to edit a link and add javascript that is rendered only right after the editing (ie if you refresh the page, there is no longer executable code anywhere)

POC :
1. add a link
2. edit its title, appending something like `" onmouseover="alert(1)"`
3. Move mouse over the newly edited link : popup appears (not good)
4. Refresh page : there is no longer any popup when you mouse over the link (good)

So, basically, you can XSS yourself 🙄 