### PR TITLE
Support HTTPS termination on a reverse proxy

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -775,6 +775,11 @@ function yourls_is_ssl() {
             $is_ssl = true;
         }
     }
+    elseif ( isset( $_SERVER[ 'HTTP_X_FORWARDED_PROTO' ] ) ) {
+        if ( 'https' == strtolower( $_SERVER[ 'HTTP_X_FORWARDED_PROTO' ] ) ) {
+            $is_ssl = true;
+        }
+    }
     elseif ( isset( $_SERVER[ 'SERVER_PORT' ] ) && ( '443' == $_SERVER[ 'SERVER_PORT' ] ) ) {
         $is_ssl = true;
     }


### PR DESCRIPTION
When HTTPS termination happens on a reverse proxy, $_SERVER['HTTPS'] is not set and $_SERVER['SERVER_PORT'] is 80.
The current implementation tries to redirect infinitely in this situation because the function yourls_is_ssl() is false, although the actual URL begins with https://.