### PR TITLE
Sanitize user input in upgrade

### DIFF
--- a/admin/upgrade.php
+++ b/admin/upgrade.php
@@ -28,8 +28,8 @@ if ( !yourls_upgrade_is_needed() ) {
 
 	// From what are we upgrading?
 	if ( isset( $_GET['oldver'] ) && isset( $_GET['oldsql'] ) ) {
-		$oldver = (string)( $_GET['oldver'] );
-		$oldsql = (string)( $_GET['oldsql'] );
+		$oldver = yourls_sanitize_version($_GET['oldver']);
+		$oldsql = (intval)($_GET['oldsql']);
 	} else {
 		list( $oldver, $oldsql ) = yourls_get_current_version_from_sql();
 	}

--- a/includes/functions-upgrade.php
+++ b/includes/functions-upgrade.php
@@ -10,6 +10,19 @@
  */
 function yourls_upgrade( $step, $oldver, $newver, $oldsql, $newsql ) {
 
+    /**
+     *  Sanitize input. Two notes :
+     *  - they should already be sanitized in the caller, eg admin/upgrade.php
+     *    (but hey, let's make sure)
+     *  - some vars may not be used at the moment
+     *    (and this is ok, they are here in case a future upgrade procedure needs them)
+     */
+    $step   = intval($step);
+    $oldsql = intval($oldsql);
+    $newsql = intval($newsql);
+    $oldver = yourls_sanitize_version($oldver);
+    $newver = yourls_sanitize_version($newver);
+
     yourls_maintenance_mode(true);
 
     // special case for 1.3: the upgrade is a multi step procedure

--- a/includes/version.php
+++ b/includes/version.php
@@ -2,11 +2,19 @@
 /**
  * YOURLS version
  *
+ * Must be one of the following :
+ *    MAJOR.MINOR (eg 1.8)
+ *    MAJOR.MINOR.PATCH (1.8.1)
+ *    MAJOR.MINOR-SOMETHING (1.8-dev)
+ *    MAJOR.MINOR.PATCH-SOMETHING (1.8.1-donotuse)
+ *
  */
 define( 'YOURLS_VERSION', '1.8.3-dev' );
 
 /**
  * YOURLS DB version. Increments when changes are made to the DB schema, to trigger a DB update
+ *
+ * Must be a string of an integer.
  *
  */
 define( 'YOURLS_DB_VERSION', '506' );


### PR DESCRIPTION
Yet another low severity XSS report sent to us.

POC : 
- install newer YOURLS files over old install
- don't load any YOURLS page or redirection that would trigger the update
- Go to `sho.rt/admin/upgrade.php?step=1&oldver=501"%20onmouseover="alert(1)"&...` or something like this

Yes, another "user can hack themselves if they really wanna" exploit.