### PR TITLE
fix: Changes to resolve #2688

### DIFF
--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -99,6 +99,7 @@ function yourls_is_valid_user() {
 			// Login form : redirect to requested URL to avoid re-submitting the login form on page reload
 			if( isset( $_REQUEST['username'] ) && isset( $_REQUEST['password'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 				yourls_redirect( yourls_sanitize_url_safe($_SERVER['REQUEST_URI']) );
+				exit(); 
 			}
 		}
 
@@ -125,7 +126,7 @@ function yourls_check_username_password() {
 
 	// If login form (not API), check for nonce
     if(!yourls_is_API()) {
-        yourls_verify_nonce('admin_login');
+        yourls_verify_nonce('admin_login', false, '-1');
     }
 
 	if( isset( $yourls_user_passwords[ $_REQUEST['username'] ] ) && yourls_check_password_hash( $_REQUEST['username'], $_REQUEST['password'] ) ) {

--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -99,7 +99,7 @@ function yourls_is_valid_user() {
 			// Login form : redirect to requested URL to avoid re-submitting the login form on page reload
 			if( isset( $_REQUEST['username'] ) && isset( $_REQUEST['password'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 				yourls_redirect( yourls_sanitize_url_safe($_SERVER['REQUEST_URI']) );
-				exit(); 
+				return;
 			}
 		}
 


### PR DESCRIPTION
This resolves the issues caused in the issue #2688.

The changes to resolve this issue are minor as follows:

- Set the `$user` variable passed to the `yourls_verify_nonce `method to '-1' (unauthorised). There seems to be an issue where the original nonce is created prior to the user logging in, and then verified after the fact. This change ensures that throughout the script execution, the same nonce is being verified
- Add an `exit()` after a redirect in `yourls_is_valid_user()`. Without this, the redirect causes the URL to be added to the database twice (or fail the second time). 

I've tested these changes on my local instance and see no issues.