### PR TITLE
Revert 3090 to fix tests

### DIFF
--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -99,7 +99,6 @@ function yourls_is_valid_user() {
 			// Login form : redirect to requested URL to avoid re-submitting the login form on page reload
 			if( isset( $_REQUEST['username'] ) && isset( $_REQUEST['password'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 				yourls_redirect( yourls_sanitize_url_safe($_SERVER['REQUEST_URI']) );
-				return;
 			}
 		}
 
@@ -126,7 +125,7 @@ function yourls_check_username_password() {
 
 	// If login form (not API), check for nonce
     if(!yourls_is_API()) {
-        yourls_verify_nonce('admin_login', false, '-1');
+        yourls_verify_nonce('admin_login');
     }
 
 	if( isset( $yourls_user_passwords[ $_REQUEST['username'] ] ) && yourls_check_password_hash( $_REQUEST['username'], $_REQUEST['password'] ) ) {

--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -475,7 +475,9 @@ function yourls_die( $message = '', $title = '', $header_code = 200 ) {
 	if( !yourls_did_action( 'html_footer' ) ) {
 		yourls_html_footer(false);
 	}
-	die();
+
+	// die with a value in case we're running tests, so PHPUnit doesn't exit with 0 as if success
+	die(1);
 }
 
 /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,7 +32,6 @@
 		<!-- Login -->
 		<request name="username" value="yourls"/>
 		<request name="password" value="secret-ci-test"/>
-		<server name="REQUEST_URI" value="/"/>
 		<!-- Install -->
 		<server name="SERVER_SOFTWARE" value="TRAVIS APACHE"/>
 		<!-- Stats data -->

--- a/tests/tests/auth/logout.php
+++ b/tests/tests/auth/logout.php
@@ -8,21 +8,23 @@
 class Logout_Func_Tests extends PHPUnit\Framework\TestCase {
 
     protected $backup_get;
+    protected $backup_request;
 
     protected function setUp(): void {
-        $this->backup_get = $_GET;
-        $_REQUEST['nonce'] = yourls_create_nonce('admin_login');
+        $this->backup_get     = $_GET;
+        $this->backup_request = $_REQUEST;
     }
 
     protected function tearDown(): void {
         $_GET = $this->backup_get;
-        yourls_remove_all_actions('pre_yourls_die');
+        $_REQUEST = $this->backup_request;
     }
 
     /**
      * Check logout procedure - phase 1
      */
     public function test_logout_user_is_logged_in() {
+        $_REQUEST['nonce'] = yourls_create_nonce('admin_login');
         $valid = yourls_is_valid_user();
         $this->assertTrue($valid);
     }
@@ -42,6 +44,7 @@ class Logout_Func_Tests extends PHPUnit\Framework\TestCase {
      * @depends test_logout_user_logs_out
      */
     public function test_logout_user_is_logged_in_back() {
+        $_REQUEST['nonce'] = yourls_create_nonce('admin_login');
         $valid = yourls_is_valid_user();
         $this->assertTrue( $valid );
     }


### PR DESCRIPTION
- Revert #3090
- Remove $_REQUEST['REQUEST_URI'] in `phpunit.xml` : less stuff in $_REQUEST = more standard tests. We should test for a redirection upon successful login in its own test
- Fix logout tests
