### PR TITLE
More checks with new version notices

### DIFF
--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -918,13 +918,16 @@ function yourls_l10n_calendar_strings() {
  * Display a notice if there is a newer version of YOURLS available
  *
  * @since 1.7
+ * @param string $compare_with Optional, YOURLS version to compare to
  */
-function yourls_new_core_version_notice() {
+function yourls_new_core_version_notice($compare_with = false) {
+    $compare_with = $compare_with ?: YOURLS_VERSION;
 
 	$checks = yourls_get_option( 'core_version_checks' );
     $latest = isset($checks->last_result->latest) ? yourls_sanitize_version($checks->last_result->latest) : false;
 
-	if( $latest AND version_compare( $latest, YOURLS_VERSION, '>' ) ) {
+	if( $latest AND version_compare( $latest, $compare_with, '>' ) ) {
+        yourls_do_action('new_core_version_notice', $latest);
 		$msg = yourls_s( '<a href="%s">YOURLS version %s</a> is available. Please update!', 'http://yourls.org/download', $latest );
 		yourls_add_notice( $msg );
 	}
@@ -986,4 +989,3 @@ function yourls_html_favicon() {
 
     printf( '<link rel="shortcut icon" href="%s" />', yourls_get_yourls_favicon_url(false) );
 }
-

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1267,5 +1267,5 @@ function yourls_set_url_scheme( $url, $scheme = false ) {
  */
 function yourls_tell_if_new_version() {
     yourls_debug_log( 'Check for new version: '.( yourls_maybe_check_core_version() ? 'yes' : 'no' ) );
-    yourls_new_core_version_notice();
+    yourls_new_core_version_notice(YOURLS_VERSION);
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -48,4 +48,17 @@ yourls_get_all_options();
 yourls_load_plugins();
 
 // At this point, tests will start
+
+// Simplify yourls_die() when running unit tests
+yourls_add_action( 'pre_yourls_die', function($params) {
+    printf("\n\nCalling yourls_die(). %s : %s (%s)\n\n", $params[1], $params[0], $params[2]);
+    echo "Last 10 Backtrace:\n";
+    $trace = debug_backtrace();
+    foreach( array_slice($trace, 0, 10) as $t ) {
+        printf("** %s:%d %s() with args\n%s\n", $t['file'], $t['line'], $t['function'], var_export($t['args'], true));
+    }
+
+    die(1);
+} );
+
 echo "YOURLS installed, starting PHPUnit\n\n";

--- a/tests/tests/http/api-check.php
+++ b/tests/tests/http/api-check.php
@@ -9,9 +9,20 @@
  */
 class HTTP_AYO_Tests extends PHPUnit\Framework\TestCase {
 
+    protected $actions, $core_version_checks;
+
+    protected function setUp(): void {
+        global $yourls_actions;
+        $this->actions = $yourls_actions;
+        $this->core_version_checks = yourls_get_option( 'core_version_checks' );
+    }
+
     protected function tearDown(): void {
         yourls_remove_all_filters( 'is_admin' );
         yourls_remove_all_filters( 'shunt_yourls_http_request' );
+        global $yourls_actions;
+        $yourls_actions = $this->actions;
+        yourls_update_option( 'core_version_checks', $this->core_version_checks );
     }
 
     /**
@@ -76,6 +87,7 @@ class HTTP_AYO_Tests extends PHPUnit\Framework\TestCase {
         $this->assertFalse( yourls_check_core_version() );
 
         $checks = yourls_get_option( 'core_version_checks' );
+        yourls_ut_var_dump( $checks );
         $after_check = $checks->failed_attempts;
 
         $this->assertEquals( $after_check, $before_check + 1 );
@@ -294,42 +306,54 @@ class HTTP_AYO_Tests extends PHPUnit\Framework\TestCase {
     public function json_responses() {
         $return = array();
 
-        // expected
-        $return[] = array(
+        $return['expected'] = array(
             (object)array(
                 'latest' => '1.2.3',
                 'zipurl' => 'https://api.github.com/repos/YOURLS/YOURLS/zipball/1.2.3',
             ),
             true);
 
-        // incorrect version number
-        $return[] = array(
+        $return['unexpected version number format'] = array(
             (object)array(
                 'latest' => '1.2.3-something',
                 'zipurl' => 'https://api.github.com/repos/YOURLS/YOURLS/zipball/1.2.3',
             ),
             false);
 
-        // url not part of github.com
-        $return[] = array(
+        $return['version mismatch'] = array(
+            (object)array(
+                'latest' => '1.2.3',
+                'zipurl' => 'https://api.github.com/repos/YOURLS/YOURLS/zipball/1.2.4',
+            ),
+            false);
+
+        $return['url not part of github.com'] = array(
             (object)array(
                 'latest' => '1.2.3',
                 'zipurl' => 'https://notgithub.com/repos/YOURLS/YOURLS/zipball/1.2.3',
             ),
             false);
 
-        // no version
-        $return[] = array(
+        $return['no version'] = array(
             (object)array(
                 'zipurl' => 'https://api.github.com/repos/YOURLS/YOURLS/zipball/1.2.3',
             ),
             false);
 
-        // no URL
-        $return[] = array(
+        $return['no URL'] = array(
             (object)array(
                 'latest' => '1.2.3',
             ),
+            false);
+
+        $return['nothing 1'] = array(
+            (object)[],
+            false);
+
+        $return['nothing 2'] = array([],
+            false);
+
+        $return['nothing 3'] = array(false,
             false);
 
         return $return;
@@ -343,6 +367,96 @@ class HTTP_AYO_Tests extends PHPUnit\Framework\TestCase {
      */
     public function test_validate_api_json_response($json, $expected) {
         $this->assertSame( $expected, yourls_validate_core_version_response($json) );
+    }
+
+    /**
+     * Provide various scenarios for version reported by api.yourls.org / current version
+     */
+    public function new_version_scenarios() {
+        $return = array();
+
+        //            AYO       current      notice
+        $return[] = ['1.2.3',  '1.2.2',      true];  // new version - display notice
+/*        $return[] = ['1.3',    '1.2.2',      true];  // new version - display notice
+        $return[] = ['1.3',    '1.22',       true];  // older version - don't display version
+        $return[] = ['1.8.22', '1.8.3',      true];  // new version - display notice
+        $return[] = ['1.2.3',  '1.2.3-beta', true];  // new version - display notice
+        $return[] = ['1.2.2',  '1.2.2',      false]; // same version - don't display notice
+        $return[] = ['1.2.2',  '1.2.3',      false]; // older version - don't display version
+        $return[] = ['99.9.9',  false,       false]; // newer version compared to actual current YOURLS version - display notice*/
+
+        return $return;
+    }
+
+    /**
+     * Test various YOURLS version strings from api.yourls.org, compare them to the actual version
+     * and make sure we display the correct update notice
+     *
+     * @dataProvider new_version_scenarios
+     */
+    public function test_new_version_notice( $api_version, $current_version, $expected ) {
+        // fake the api response
+        $check = (object)array(
+            'last_result' => (object)array(
+                'latest' => $api_version,
+            ),
+        );
+        yourls_add_option('core_version_checks', $check);
+
+        // trigger yourls_core_version_notice() and check we had expected action
+        yourls_new_core_version_notice($current_version);
+        $this->assertSame($expected, yourls_did_action('new_core_version_notice'));
+    }
+
+    /**
+     * Test various zipball URLs and get version number from it
+     */
+    function various_zipball_url_version() {
+        $return = [];
+
+        $return[] = ['https://api.github.com/repos/YOURLS/YOURLS/zipball/1.2.3', '1.2.3'];
+        $return[] = ['https://api.github.com/repos/YOURLS/YOURLS/zipball/1.2.3-beta', '1.2.3-beta'];
+        $return[] = ['https://api.github.com/repos/YOURLS/YOURLS/zipball/1.2.3/lol', 'lol'];
+        $return[] = ['http://hey', ''];
+        $return[] = ['lol', ''];
+        $return[] = ['', ''];
+
+        return $return;
+    }
+
+    /**
+     * Test various zipball URLs and get version number from it
+     *
+     * @dataProvider various_zipball_url_version
+     */
+    public function test_get_version_from_zipball_url($url, $expected) {
+        $this->assertSame($expected, yourls_get_version_from_zipball_url($url));
+    }
+
+
+    /**
+     * test various core version JSON responses from api.yourls.org
+     */
+    function get_various_json_response_keys() {
+        $return = [];
+
+        $return['latest & zipurl'] = [['latest' => 'ok', 'zipurl' => 'ok'], true];
+        $return['no latest'] = [['zipurl' => 'ok'], false];
+        $return['no zipurl'] = [['latest' => 'ok'], false];
+        $return['latest & other key'] = [['latest' => 'ok', 'other' => 'oops'], false];
+        $return['zipurl & other key'] = [['zipurl' => 'ok', 'other' => 'oops'], false];
+        $return['nothing'] = [[], false];
+        $return['extra key'] = [['latest' => 'ok', 'zipurl' => 'ok', 'extra' => 'oops'], false];
+
+        return $return;
+    }
+
+    /**
+     * Check yourls_validate_core_version_response_keys() works as expected
+     * @dataProvider get_various_json_response_keys
+     */
+    function test_yourls_validate_core_version_response_keys($json, $expected) {
+        $this->assertSame(yourls_validate_core_version_response_keys((object)$json), $expected);
     }
 
 }


### PR DESCRIPTION
Motivations :
  * add unit tests to make sure running 1.8.3-dev will trigger a new version notice when 1.8.3 is out (I think it already works this way)
  * more validation of the api core/update response to make sure all keys and only these keys are returned