### PR TITLE
Fix broken edit/delete buttons on some occasions.

### DIFF
--- a/admin/admin-ajax.php
+++ b/admin/admin-ajax.php
@@ -23,19 +23,19 @@ switch( $action ) {
 		break;
 
 	case 'edit_display':
-		yourls_verify_nonce( 'edit-link_'.$_REQUEST['id'], $_REQUEST['nonce'], false, 'omg error' );
+		yourls_verify_nonce( 'edit-link_'.$_REQUEST['elid'], $_REQUEST['nonce'], false, 'omg error' );
 		$row = yourls_table_edit_row ( $_REQUEST['keyword'] );
 		echo json_encode( array('html' => $row) );
 		break;
 
 	case 'edit_save':
-		yourls_verify_nonce( 'edit-save_'.$_REQUEST['id'], $_REQUEST['nonce'], false, 'omg error' );
+		yourls_verify_nonce( 'edit-save_'.$_REQUEST['elid'], $_REQUEST['nonce'], false, 'omg error' );
 		$return = yourls_edit_link( $_REQUEST['url'], $_REQUEST['keyword'], $_REQUEST['newkeyword'], $_REQUEST['title'] );
 		echo json_encode($return);
 		break;
 
 	case 'delete':
-		yourls_verify_nonce( 'delete-link_'.$_REQUEST['id'], $_REQUEST['nonce'], false, 'omg error' );
+		yourls_verify_nonce( 'delete-link_'.$_REQUEST['elid'], $_REQUEST['nonce'], false, 'omg error' );
 		$query = yourls_delete_link_by_keyword( $_REQUEST['keyword'] );
 		echo json_encode(array('success'=>$query));
 		break;

--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -555,11 +555,11 @@ function yourls_table_add_row( $keyword, $url, $title, $ip, $clicks, $timestamp 
 	$statlink = yourls_statlink( $keyword );
 
 	$delete_link = yourls_nonce_url( 'delete-link_'.$id,
-		yourls_add_query_arg( array( 'id' => $id, 'action' => 'delete', 'keyword' => $keyword ), yourls_admin_url( 'admin-ajax.php' ) )
+		yourls_add_query_arg( array( 'elid' => $id, 'action' => 'delete', 'keyword' => $keyword ), yourls_admin_url( 'admin-ajax.php' ) )
 	);
 
 	$edit_link = yourls_nonce_url( 'edit-link_'.$id,
-		yourls_add_query_arg( array( 'id' => $id, 'action' => 'edit', 'keyword' => $keyword ), yourls_admin_url( 'admin-ajax.php' ) )
+		yourls_add_query_arg( array( 'elid' => $id, 'action' => 'edit', 'keyword' => $keyword ), yourls_admin_url( 'admin-ajax.php' ) )
 	);
 
 	// Action link buttons: the array

--- a/js/insert.js
+++ b/js/insert.js
@@ -78,7 +78,7 @@ function edit_link_display(id) {
 	var nonce = get_var_from_query( $('#edit-button-'+id).attr('href'), 'nonce' );
 	$.getJSON(
 		ajaxurl,
-		{ action: "edit_display", keyword: keyword, nonce: nonce, id: id },
+		{ action: "edit_display", keyword: keyword, nonce: nonce, elid: id },
 		function(data){
 			$("#id-" + id).after( data.html );
 			$("#edit-url-"+ id).focus();
@@ -99,7 +99,7 @@ function remove_link(id) {
 	var nonce = get_var_from_query( $('#delete-button-'+id).attr('href'), 'nonce' );
 	$.getJSON(
 		ajaxurl,
-		{ action: "delete", keyword: keyword, nonce: nonce, id: id },
+		{ action: "delete", keyword: keyword, nonce: nonce, elid: id },
 		function(data){
 			if (data.success == 1) {
 				$("#id-" + id).fadeOut(function(){
@@ -143,7 +143,7 @@ function edit_link_save(id) {
 	var www = $('#yourls-site').val();
 	$.getJSON(
 		ajaxurl,
-		{action:'edit_save', url: newurl, id: id, keyword: keyword, newkeyword: newkeyword, title: title, nonce: nonce },
+		{action:'edit_save', url: newurl, elid: id, keyword: keyword, newkeyword: newkeyword, title: title, nonce: nonce },
 		function(data){
 			if(data.status == 'success') {
 


### PR DESCRIPTION
This issue is described in:
Used to work - can no longer add edit short urls - nothing changed #2102

At least one cause of this can be if a reverse proxy (e.g. cloudflared tunnel) sends an "id" parameter on every request, the nonce verification for the edit and delete buttons breaks.

This change is to rename the parameter to "elid" to prevent it conflicting with the "id" param. This resolves the issue and the buttons work again.