### PR TITLE
No hyphen in random keywords

### DIFF
--- a/includes/functions-shorturls.php
+++ b/includes/functions-shorturls.php
@@ -168,11 +168,6 @@ function yourls_add_new_link( $url, $keyword = '', $title = '' ) {
  * @return string    Acceptable charset for short URLS keywords
  */
 function yourls_get_shorturl_charset() {
-    static $charset = null;
-    if ( $charset !== null ) {
-        return $charset;
-    }
-
     if ( defined( 'YOURLS_URL_CONVERT' ) && in_array( YOURLS_URL_CONVERT, [ 62, 64 ] ) ) {
         $charset = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
     }

--- a/user/plugins/hyphens-in-urls/plugin.php
+++ b/user/plugins/hyphens-in-urls/plugin.php
@@ -1,19 +1,27 @@
 <?php
-/*
-Plugin Name: Allow Hyphens in Short URLs
-Plugin URI: http://yourls.org/
-Description: Allow hyphens in short URLs (like <tt>http://sho.rt/hello-world</tt>)
-Version: 1.0
-Author: Ozh
-Author URI: http://ozh.org/
-*/
+/**
+ * Plugin Name: Allow Hyphens in Short URLs
+ * Plugin URI: http://yourls.org/
+ * Description: Allow hyphens in short URLs (like <tt>http://sho.rt/hello-world</tt>)
+ * Version: 1.1
+ * Author: Ozh
+ * Author URI: http://ozh.org/
+ */
+
+/** Release History:
+ *
+ * 1.0 Initial release
+ * 1.1 Modified: Make random keywords hyphen free
+ */
 
 // No direct call
 if( !defined( 'YOURLS_ABSPATH' ) ) die();
 
+// Add hyphen to the allowed character set
 yourls_add_filter( 'get_shorturl_charset', 'ozh_hyphen_in_charset' );
+// Unless we are crafting a random keyword
+yourls_add_action('add_new_link_create_keyword', function() {yourls_remove_filter('get_shorturl_charset', 'ozh_hyphen_in_charset');});
+
 function ozh_hyphen_in_charset( $in ) {
 	return $in.'-';
 }
-
-


### PR DESCRIPTION
When someone enables `hyphens-in-urls` and `random-shorturls`, randomly generated keyword should not contain hyphen because it's counter intuitive (people want hyphen to make up short URL like "hello-world" but don't want "jdK-Lg" as a random one) and potentially misleading when the hyphen is the leading or trailing char of the short URL.

This PR :
- disables the hyphen when generating a random keyword
- removes the useless use of a static var in `yourls_get_shorturl_charset()` that was preventing filters to correctly work