### PR TITLE
Support for DB upgrades from CLI and performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.config
 *.conf
 [Rr]obots.txt
+.maintenance
 
 # Ignore everything in user/
 user/*

--- a/cli/upgrade.php
+++ b/cli/upgrade.php
@@ -1,0 +1,53 @@
+<?php
+define( 'YOURLS_ADMIN', true );
+define( 'YOURLS_UPGRADING', true );
+require_once( dirname( __DIR__ ).'/includes/load-yourls.php' );
+
+if (isset($_SERVER["HTTP_HOST"])) {
+    die("This script can not be run from within a web browser.");
+}
+
+if ( yourls_upgrade_is_needed() ) {
+	echo yourls_s( 'Upgrade not required. Already fully upgraded.' );
+} else {
+	/*
+	step 1: create new tables and populate them, update old tables structure,
+	step 2: convert each row of outdated tables if needed
+	step 3: - if applicable finish updating outdated tables (indexes etc)
+	        - update version & db_version in options, this is all done!
+	*/
+
+    list( $oldver, $oldsql ) = yourls_get_current_version_from_sql();
+
+	// To what are we upgrading ?
+	$newver = YOURLS_VERSION;
+	$newsql = YOURLS_DB_VERSION;
+
+	// Verbose & ugly details
+	yourls_debug_mode(true);
+
+    echo_bold(yourls_translate( 'Your current installation needs to be upgraded.' . PHP_EOL ));
+    echo yourls_translate( 'Please, pretty please, it is recommended that you ');
+    echo_bold(yourls_translate( 'backup your database' . PHP_EOL ));
+    echo yourls_translate( '(you should do this regularly anyway)' . PHP_EOL );
+    echo yourls_translate( 'Nothing awful ');
+    echo_bold(yourls_translate( 'should' . ' '));
+    echo yourls_translate( " happen, but this doesn't mean it ");
+    echo_bold(yourls_translate("won't" . ' ' ));
+    echo yourls_translate( 'happen, right? ;)' . PHP_EOL );
+    echo yourls_translate( 'On every step, if ');
+    echo_error( yourls_translate( 'something goes wrong' . ', ' ));
+    echo yourls_translate( "you'll see a message and hopefully a way to fix." . PHP_EOL );
+    echo yourls_translate( 'If everything goes too fast and you cannot read, ');
+    echo_success( yourls_translate('good for you' . ', ' ));
+    echo yourls_translate( 'let it go :)' . PHP_EOL );
+    echo yourls_translate( 'Would you like to proceed? (y/N)' );
+
+    $input = readline();
+    $input = strtoupper($input);
+
+    if ($input == 'Y') {
+        yourls_upgrade( 1, $oldver, $newver, $oldsql, $newsql, true );
+    }
+
+}

--- a/includes/functions-upgrade.php
+++ b/includes/functions-upgrade.php
@@ -12,9 +12,10 @@
  * @param string $newver
  * @param string|int $oldsql
  * @param string|int $newsql
+ * @param bool $cli
  * @return void
  */
-function yourls_upgrade($step, $oldver, $newver, $oldsql, $newsql ) {
+function yourls_upgrade($step, $oldver, $newver, $oldsql, $newsql, $cli = false ) {
 
     /**
      *  Sanitize input. Two notes :
@@ -42,16 +43,16 @@ function yourls_upgrade($step, $oldver, $newver, $oldsql, $newsql ) {
 	case 1:
 	case 2:
 		if( $oldsql < 210 )
-			yourls_upgrade_to_141();
+			yourls_upgrade_to_141($cli);
 
 		if( $oldsql < 220 )
-			yourls_upgrade_to_143();
+			yourls_upgrade_to_143($cli);
 
 		if( $oldsql < 250 )
-			yourls_upgrade_to_15();
+			yourls_upgrade_to_15($cli);
 
 		if( $oldsql < 482 )
-			yourls_upgrade_482(); // that was somewhere 1.5 and 1.5.1 ...
+			yourls_upgrade_482($cli); // that was somewhere 1.5 and 1.5.1 ...
 
 		if( $oldsql < 506 ) {
             /**
@@ -62,13 +63,21 @@ function yourls_upgrade($step, $oldver, $newver, $oldsql, $newsql ) {
              *      people before 505 to update to the FIXED complete upgrade
              */
 			if( $oldsql == 505 ) {
-                yourls_upgrade_505_to_506();
+                yourls_upgrade_505_to_506($cli);
             } else {
-                yourls_upgrade_to_506();
+                yourls_upgrade_to_506($cli);
             }
         }
 
-		yourls_redirect_javascript( yourls_admin_url( "upgrade.php?step=3" ) );
+		if( $oldsql < 507 ) {
+			yourls_upgrade_to_507($cli);
+		}
+
+		if ($cli) {
+			yourls_upgrade(3, $oldver, $newver, $oldsql, $newsql, $cli);
+		} else {
+			yourls_redirect_javascript(yourls_admin_url("upgrade.php?step=3"));
+		}
 
 		break;
 
@@ -81,71 +90,63 @@ function yourls_upgrade($step, $oldver, $newver, $oldsql, $newsql ) {
 	}
 }
 
+/************************** 1.8 -> 1.9 **************************/
+
+/**
+ * Update to 507
+ *
+ * @param bool $cli
+ * @return void
+ */
+function yourls_upgrade_to_507($cli)
+{
+	display_notification('Adding indexes. Please wait...', $cli);
+
+	$queries = array(
+		sprintf('ALTER TABLE `%s` ADD INDEX clicks(`clicks`);', YOURLS_DB_TABLE_URL),
+		sprintf('ALTER TABLE `%s` ADD INDEX click_time(`click_time`);', YOURLS_DB_TABLE_LOG),
+	);
+
+	execute_update_queries($queries, $cli);
+}
+
 /************************** 1.6 -> 1.8 **************************/
 
 /**
  * Update to 506, just the fix for people who had updated to master on 1.7.10
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_upgrade_505_to_506() {
-    echo "<p>Updating DB. Please wait...</p>";
-	// Fix collation which was wrongly set at first to utf8mb4_unicode_ci
-	$query = sprintf('ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;', YOURLS_DB_TABLE_URL);
+function yourls_upgrade_505_to_506($cli) {
+    display_notification('Fixing character set. Please wait...', $cli);
 
-    try {
-        yourls_get_db()->perform($query);
-    } catch (\Exception $e) {
-        echo "<p class='error'>Unable to update the DB.</p>";
-        echo "<p>Could not change collation. You will have to fix things manually :(. The error was
-        <pre>";
-        echo $e->getMessage();
-        echo "/n</pre>";
-        die();
-    }
+	$queries = array(
+        sprintf('ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;', YOURLS_DB_TABLE_URL)
+    );
 
-    echo "<p class='success'>OK!</p>";
+    execute_update_queries($queries, $cli);
 }
 
 /**
  * Update to 506
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_upgrade_to_506() {
-    $ydb = yourls_get_db();
-    $error_msg = [];
+function yourls_upgrade_to_506($cli) {
+    display_notification('Fixing character sets. Please wait...', $cli);
 
-    echo "<p>Updating DB. Please wait...</p>";
+	$queries = array(
+		sprintf('ALTER DATABASE `%s` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;', YOURLS_DB_NAME),
+		sprintf('ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;', YOURLS_DB_TABLE_OPTIONS),
+		sprintf("ALTER TABLE `%s` CHANGE `keyword` `keyword` VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT ''," .
+			"CHANGE `url` `url` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL," .
+			"CHANGE `title` `title` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci," .
+			"CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;", YOURLS_DB_TABLE_URL),
+	);
 
-    $queries = array(
-        'database charset'     => sprintf('ALTER DATABASE `%s` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;', YOURLS_DB_NAME),
-        'options charset'      => sprintf('ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;', YOURLS_DB_TABLE_OPTIONS),
-        'short URL varchar'    => sprintf("ALTER TABLE `%s` CHANGE `keyword` `keyword` VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';", YOURLS_DB_TABLE_URL),
-        'short URL type url'   => sprintf("ALTER TABLE `%s` CHANGE `url` `url` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;", YOURLS_DB_TABLE_URL),
-        'short URL type title' => sprintf("ALTER TABLE `%s` CHANGE `title` `title` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci", YOURLS_DB_TABLE_URL),
-        'short URL charset'    => sprintf('ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;', YOURLS_DB_TABLE_URL),
-    );
-
-    foreach($queries as $what => $query) {
-        try {
-            $ydb->perform($query);
-        } catch (\Exception $e) {
-            $error_msg[] = $e->getMessage();
-        }
-    }
-
-    if( $error_msg ) {
-        echo "<p class='error'>Unable to update the DB.</p>";
-        echo "<p>You will have to manually fix things, sorry for the inconvenience :(</p>";
-        echo "<p>The errors were:
-        <pre>";
-        foreach( $error_msg as $error ) {
-            echo "$error\n";
-        }
-        echo "</pre>";
-        die();
-    }
-
-    echo "<p class='success'>OK!</p>";
+	execute_update_queries($queries, $cli);
 }
 
 /************************** 1.5 -> 1.6 **************************/
@@ -153,13 +154,16 @@ function yourls_upgrade_to_506() {
 /**
  * Upgrade r482
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_upgrade_482() {
+function yourls_upgrade_482($cli) {
+	display_notification('Updating table structure. Please wait...', $cli);
+
 	// Change URL title charset to UTF8
 	$table_url = YOURLS_DB_TABLE_URL;
 	$sql = "ALTER TABLE `$table_url` CHANGE `title` `title` TEXT CHARACTER SET utf8;";
 	yourls_get_db()->perform( $sql );
-	echo "<p>Updating table structure. Please wait...</p>";
 }
 
 /************************** 1.4.3 -> 1.5 **************************/
@@ -167,22 +171,24 @@ function yourls_upgrade_482() {
 /**
  * Main func for upgrade from 1.4.3 to 1.5
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_upgrade_to_15( ) {
+function yourls_upgrade_to_15($cli) {
 	// Create empty 'active_plugins' entry in the option if needed
+	display_notification('Enabling the plugin API. Please wait...', $cli);
 	if( yourls_get_option( 'active_plugins' ) === false )
 		yourls_add_option( 'active_plugins', array() );
-	echo "<p>Enabling the plugin API. Please wait...</p>";
 
 	// Alter URL table to store titles
+	display_notification('Updating table structure. Please wait...', $cli);
 	$table_url = YOURLS_DB_TABLE_URL;
 	$sql = "ALTER TABLE `$table_url` ADD `title` TEXT AFTER `url`;";
 	yourls_get_db()->perform( $sql );
-	echo "<p>Updating table structure. Please wait...</p>";
 
 	// Update .htaccess
+	display_notification('Updating .htaccess file. Please wait...', $cli);
 	yourls_create_htaccess();
-	echo "<p>Updating .htaccess file. Please wait...</p>";
 }
 
 /************************** 1.4.1 -> 1.4.3 **************************/
@@ -190,8 +196,10 @@ function yourls_upgrade_to_15( ) {
 /**
  * Main func for upgrade from 1.4.1 to 1.4.3
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_upgrade_to_143( ) {
+function yourls_upgrade_to_143($cli) {
 	// Check if we have 'keyword' (borked install) or 'shorturl' (ok install)
 	$ydb = yourls_get_db();
 	$table_log = YOURLS_DB_TABLE_LOG;
@@ -201,7 +209,7 @@ function yourls_upgrade_to_143( ) {
 		$sql = "ALTER TABLE `$table_log` CHANGE `keyword` `shorturl` VARCHAR( 200 ) BINARY;";
 		$ydb->query( $sql );
 	}
-	echo "<p>Structure of existing tables updated. Please wait...</p>";
+    display_notification('Structure of existing tables updated. Please wait...', $cli);
 }
 
 /************************** 1.4 -> 1.4.1 **************************/
@@ -209,13 +217,15 @@ function yourls_upgrade_to_143( ) {
 /**
  * Main func for upgrade from 1.4 to 1.4.1
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_upgrade_to_141( ) {
+function yourls_upgrade_to_141($cli) {
 	// Kill old cookies from 1.3 and prior
 	setcookie('yourls_username', '', time() - 3600 );
 	setcookie('yourls_password', '', time() - 3600 );
 	// alter table URL
-	yourls_alter_url_table_to_141();
+	yourls_alter_url_table_to_141($cli);
 	// recreate the htaccess file if needed
 	yourls_create_htaccess();
 }
@@ -223,12 +233,14 @@ function yourls_upgrade_to_141( ) {
 /**
  * Alter table URL to 1.4.1
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_alter_url_table_to_141() {
+function yourls_alter_url_table_to_141($cli) {
 	$table_url = YOURLS_DB_TABLE_URL;
 	$alter = "ALTER TABLE `$table_url` CHANGE `keyword` `keyword` VARCHAR( 200 ) BINARY, CHANGE `url` `url` TEXT BINARY ";
-	yourls_get_db()->perform( $alter );
-	echo "<p>Structure of existing tables updated. Please wait...</p>";
+	yourls_get_db()->perform($alter);
+	display_notification('Structure of existing tables updated. Please wait...', $cli);
 }
 
 
@@ -237,45 +249,64 @@ function yourls_alter_url_table_to_141() {
 /**
  * Main func for upgrade from 1.3-RC1 to 1.4
  *
+ * @param int $step
+ * @param bool $cli
+ * @return void
  */
-function yourls_upgrade_to_14( $step ) {
+function yourls_upgrade_to_14($step, $cli) {
+	switch ($step) {
+		case 1:
+			// create table log & table options
+			// update table url structure
+			// update .htaccess
+			yourls_create_tables_for_14($cli); // no value returned, assuming it went OK
+			yourls_alter_url_table_to_14($cli); // no value returned, assuming it went OK
+			$clean = yourls_clean_htaccess_for_14($cli); // returns bool
+			$create = yourls_create_htaccess(); // returns bool
 
-	switch( $step ) {
-	case 1:
-		// create table log & table options
-		// update table url structure
-		// update .htaccess
-		yourls_create_tables_for_14(); // no value returned, assuming it went OK
-		yourls_alter_url_table_to_14(); // no value returned, assuming it went OK
-		$clean = yourls_clean_htaccess_for_14(); // returns bool
-		$create = yourls_create_htaccess(); // returns bool
-		if ( !$create )
-			echo "<p class='warning'>Please create your <tt>.htaccess</tt> file (I could not do it for you). Please refer to <a href='http://yourls.org/htaccess'>http://yourls.org/htaccess</a>.";
-		yourls_redirect_javascript( yourls_admin_url( "upgrade.php?step=2&oldver=1.3&newver=1.4&oldsql=100&newsql=200" ), $create );
-		break;
+			if ($cli) {
+				if (!$create) {
+					echo_warning(yourls_translate('Please create your .htaccess file (I could not do it for you).') . PHP_EOL);
+					echo_warning(yourls_translate('Please refer to: http://yourls.org/htaccess') . PHP_EOL);
+				}
+				yourls_upgrade(1, '1.3', '1.4', 100, 200, true);
+			} else {
+				if (!$create) {
+					echo "<p class='warning'>Please create your <tt>.htaccess</tt> file (I could not do it for you). Please refer to <a href='http://yourls.org/htaccess'>http://yourls.org/htaccess</a>.";
+				}
+				yourls_redirect_javascript(yourls_admin_url("upgrade.php?step=2&oldver=1.3&newver=1.4&oldsql=100&newsql=200"), $create);
+			}
 
-	case 2:
-		// convert each link in table url
-		yourls_update_table_to_14();
-		break;
+			break;
+		case 2:
+			// convert each link in table url
+			yourls_update_table_to_14($cli);
+			break;
 
-	case 3:
-		// update table url structure part 2: recreate indexes
-		yourls_alter_url_table_to_14_part_two();
-		// update version & db_version & next_id in the option table
-		// attempt to drop YOURLS_DB_TABLE_NEXTDEC
-		yourls_update_options_to_14();
-		// Now upgrade to 1.4.1
-		yourls_redirect_javascript( yourls_admin_url( "upgrade.php?step=1&oldver=1.4&newver=1.4.1&oldsql=200&newsql=210" ) );
-		break;
+		case 3:
+			// update table url structure part 2: recreate indexes
+			yourls_alter_url_table_to_14_part_two($cli);
+			// update version & db_version & next_id in the option table
+			// attempt to drop YOURLS_DB_TABLE_NEXTDEC
+			yourls_update_options_to_14($cli);
+			// Now upgrade to 1.4.1
+
+			if ($cli) {
+				yourls_upgrade(1, '1.4', '1.4.1', 200, 210, true);
+			} else {
+				yourls_redirect_javascript(yourls_admin_url("upgrade.php?step=1&oldver=1.4&newver=1.4.1&oldsql=200&newsql=210"));
+			}
+			break;
 	}
 }
 
 /**
  * Update options to reflect new version
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_update_options_to_14() {
+function yourls_update_options_to_14($cli) {
 	yourls_update_option( 'version', '1.4' );
 	yourls_update_option( 'db_version', '200' );
 
@@ -292,8 +323,10 @@ function yourls_update_options_to_14() {
 /**
  * Create new tables for YOURLS 1.4: options & log
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_create_tables_for_14() {
+function yourls_create_tables_for_14($cli) {
 	$ydb = yourls_get_db();
 
 	$queries = array();
@@ -324,20 +357,20 @@ function yourls_create_tables_for_14() {
 		$ydb->perform( $query ); // There's no result to be returned to check if table was created (except making another query to check table existence, which we'll avoid)
 	}
 
-	echo "<p>New tables created. Please wait...</p>";
-
+	display_notification('New tables created. Please wait...', $cli);
 }
 
 /**
  * Alter table structure, part 1 (change schema, drop index)
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_alter_url_table_to_14() {
+function yourls_alter_url_table_to_14($cli) {
 	$ydb = yourls_get_db();
 	$table = YOURLS_DB_TABLE_URL;
 
 	$alters = array();
-	$results = array();
 	$alters[] = "ALTER TABLE `$table` CHANGE `id` `keyword` VARCHAR( 200 ) NOT NULL";
 	$alters[] = "ALTER TABLE `$table` CHANGE `url` `url` TEXT NOT NULL";
 	$alters[] = "ALTER TABLE `$table` DROP PRIMARY KEY";
@@ -346,14 +379,16 @@ function yourls_alter_url_table_to_14() {
 		$ydb->perform( $query );
 	}
 
-	echo "<p>Structure of existing tables updated. Please wait...</p>";
+	display_notification('Structure of existing tables updated. Please wait...', $cli);
 }
 
 /**
  * Alter table structure, part 2 (recreate indexes after the table is up to date)
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_alter_url_table_to_14_part_two() {
+function yourls_alter_url_table_to_14_part_two($cli) {
 	$ydb = yourls_get_db();
 	$table = YOURLS_DB_TABLE_URL;
 
@@ -366,14 +401,16 @@ function yourls_alter_url_table_to_14_part_two() {
 		$ydb->perform( $query );
 	}
 
-	echo "<p>New table index created</p>";
+	display_notification('New table indexes created', $cli);
 }
 
 /**
  * Convert each link from 1.3 (id) to 1.4 (keyword) structure
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_update_table_to_14() {
+function yourls_update_table_to_14($cli) {
 	$ydb = yourls_get_db();
 	$table = YOURLS_DB_TABLE_URL;
 
@@ -396,7 +433,15 @@ function yourls_update_table_to_14() {
 		if( true === $ydb->perform("UPDATE `$table` SET `keyword` = '$newkeyword' WHERE `url` = '$url';") ) {
 			$queries++;
 		} else {
-			echo "<p>Huho... Could not update rown with url='$url', from keyword '$keyword' to keyword '$newkeyword'</p>"; // Find what went wrong :/
+			$error = yourls_translate('ERROR: Could not update row with url') . "='$url', ";
+			$error .= yourls_translate('from keyword') . " '$keyword' ";
+			$error .= yourls_translate('to keyword') . " '$newkeyword'";
+
+			if ($cli) {
+				echo_error($error . PHP_EOL);
+			} else {
+				echo "<p>$error</p>"; // Find what went wrong :/
+			}
 		}
 		$count++;
 	}
@@ -406,19 +451,40 @@ function yourls_update_table_to_14() {
 	if( $count != $queries ) {
 		$success = false;
 		$num = $count - $queries;
-		echo "<p>$num error(s) occured while updating the URL table :(</p>";
+		$error = "$num " . yourls_translate('error(s) occurred while updating the URL table :(');
+
+		if ($cli) {
+			echo_error($error . PHP_EOL);
+		} else {
+			echo "<p>$error</p>";
+		}
 	}
 
 	if ( $count == $chunk ) {
 		// there are probably other rows to convert
 		$from = $from + $chunk;
 		$remain = $total - $from;
-		echo "<p>Converted $chunk database rows ($remain remaining). Continuing... Please do not close this window until it's finished!</p>";
-		yourls_redirect_javascript( yourls_admin_url( "upgrade.php?step=2&oldver=1.3&newver=1.4&oldsql=100&newsql=200&from=$from" ), $success );
+		$text = yourls_translate('Converted') . " $chunk";
+		$text .= yourls_translate('database rows') . " ($remain " . yourls_translate('remaining') . ') ';
+		$text .= yourls_translate('Continuing...');
+
+		if ($cli) {
+			echo $text;
+			yourls_upgrade(2, '1.3', '1.4', 100, 200, true);
+		} else {
+			$text .= ' ' . yourls_translate("Please do not close this window until it's finished!");
+			echo "<p>$text</p>";
+			yourls_redirect_javascript(yourls_admin_url("upgrade.php?step=2&oldver=1.3&newver=1.4&oldsql=100&newsql=200&from=$from"), $success);
+		}
 	} else {
 		// All done
-		echo '<p>All rows converted! Please wait...</p>';
-		yourls_redirect_javascript( yourls_admin_url( "upgrade.php?step=3&oldver=1.3&newver=1.4&oldsql=100&newsql=200" ), $success );
+		display_notification('All rows converted! Please wait...');
+
+		if ($cli) {
+			yourls_upgrade(2, '1.3', '1.4', 100, 200, true);
+		} else {
+			yourls_redirect_javascript(yourls_admin_url("upgrade.php?step=3&oldver=1.3&newver=1.4&oldsql=100&newsql=200"), $success);
+		}
 	}
 
 }
@@ -426,8 +492,10 @@ function yourls_update_table_to_14() {
 /**
  * Clean .htaccess as it existed before 1.4. Returns boolean
  *
+ * @param bool $cli
+ * @return void
  */
-function yourls_clean_htaccess_for_14() {
+function yourls_clean_htaccess_for_14($cli) {
 	$filename = YOURLS_ABSPATH.'/.htaccess';
 
 	$result = false;
@@ -450,4 +518,124 @@ function yourls_clean_htaccess_for_14() {
 	}
 
 	return $result;
+}
+
+/**
+ * Echo text in bold within the CLI
+ *
+ * @param string $str Text string
+ * @return void
+ * @since 1.9.2
+ */
+function echo_bold($str) {
+	echo "\033[97m" . $str;
+	echo "\033[0m";
+}
+
+/**
+ * Echo text in red within the CLI
+ *
+ * @param string $str Text string
+ * @return void
+ * @since 1.9.2
+ */
+function echo_error($str) {
+	echo "\033[31;1m" . $str;
+	echo "\033[0m";
+}
+
+/**
+ * Echo text in green within the CLI
+ *
+ * @param string $str Text string
+ * @return void
+ * @since 1.9.2
+ */
+function echo_success($str) {
+	echo "\033[32;1m" . $str;
+	echo "\033[0m";
+}
+
+/**
+ * Echo text in green within the CLI
+ *
+ * @param string $str Text string
+ * @return void
+ * @since 1.9.2
+ */
+function echo_warning($str) {
+	echo "\033[33;1m" . $str;
+	echo "\033[0m";
+}
+
+/**
+ * Execute update queries
+ *
+ * @param array $qyeries Queries
+ * @param bool $cli Whether run from CLI or browser
+ * @return void
+ * @since 1.9.2
+ */
+function execute_update_queries($queries, $cli) {
+	$ydb = yourls_get_db();
+	$error_msg = [];
+
+	if ($cli) {
+		echo_bold(yourls_translate('Updating DB. Please wait...') . PHP_EOL);
+	} else {
+		echo '<p>' . yourls_translate('Updating DB. Please wait...') . '</p>';
+	}
+
+	foreach ($queries as $query) {
+		try {
+			$ydb->perform($query);
+		} catch (\Exception $e) {
+			$error_msg[] = $e->getMessage();
+		}
+	}
+
+	if ($error_msg) {
+		if ($cli) {
+			echo_error(yourls_translate('Unable to update the DB.') . PHP_EOL);
+			echo yourls_translate('You will have to manually fix things, sorry for the inconvenience :(') . PHP_EOL;
+			echo yourls_translate('The errors were:') . PHP_EOL;
+			foreach ($error_msg as $error) {
+				echo "$error\n";
+			}
+		} else {
+			echo "<p class='error'>" . yourls_translate('Unable to update the DB') . "</p>";
+			echo "<p>" . yourls_translate('You will have to manually fix things, sorry for the inconvenience :(') . "</p>";
+			echo "<p>" . yourls_translate('The errors were:') . "
+            <pre>";
+			foreach ($error_msg as $error) {
+				echo "$error\n";
+			}
+			echo "</pre>";
+		}
+		die();
+	}
+
+	if ($cli) {
+		echo_success('OK!' . PHP_EOL);
+	} else {
+		echo "<p class='success'>OK!</p>";
+	}
+}
+
+/**
+ * Display notification
+ *
+ * @param string $text Text to display
+ * @param bool $cli Whether run from CLI or browser
+ * @return void
+ * @since 1.9.2
+ */
+function display_notification($text, $cli) {
+	$text = yourls_translate($text);
+
+	if ($cli) {
+		echo_bold($text);
+	} else {
+		echo "<p>$text</p>";
+	}
 }


### PR DESCRIPTION
Fixes for #3427:

- Updated `yourls_upgrade_to_506()` to perform a single ALTER on the same table to improve efficiency.
- Added `yourls_upgrade_to_507()` to add additional indexes (admin page takes over a minute to count clicks on a large DB).
- Added support for upgrading DB from the CLI because a web browser times out when the DB is large.