### PR TITLE
Add backwards compatibility to yourls_salt function (#3491)

### DIFF
--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -597,6 +597,11 @@ function yourls_tick() {
  */
 function yourls_salt( $string ) {
 	$salt = defined('YOURLS_COOKIEKEY') ? YOURLS_COOKIEKEY : md5(__FILE__) ;
+
+	if (defined('YOURLS_SALT_FUNCTION') and in_array(YOURLS_SALT_FUNCTION, hash_algos())) {
+		return yourls_apply_filter('yourls_salt', (YOURLS_SALT_FUNCTION)($string . $salt), $string);
+	}
+
 	return yourls_apply_filter( 'yourls_salt', hash_hmac( yourls_hmac_algo(), $string,  $salt), $string );
 }
 


### PR DESCRIPTION
Provides backwards compatibility for the `yourls_salt` function, so that people who are already using `md5` can continue to do so by adding the following line of code to their config.php file:

```php
define ( 'YOURLS_SALT_FUNCTION', 'md5' );
```

Resolves #3491 .