### PR TITLE
Replace deprecated uses of `set-output` in Actions

### DIFF
--- a/.github/workflows/update-certificates.yml
+++ b/.github/workflows/update-certificates.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: "Get date"
         id: get-date
-        run: echo "::set-output name=DATE::$(/bin/date -u "+%F")"
+        run: echo "DATE=$(/bin/date -u "+%F")" >> $GITHUB_OUTPUT
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/update-geoip.yml
+++ b/.github/workflows/update-geoip.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: "Get date"
         id: get-date
-        run: echo "::set-output name=DATE::$(/bin/date -u "+%F")"
+        run: echo "DATE=$(/bin/date -u "+%F")" >> $GITHUB_OUTPUT
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
Tin. Deadline is May 31.

Announcement: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/