### PR TITLE
fixes issue #3523 'Bookmarklet strips + in long URL'

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -110,10 +110,10 @@ if ( isset( $_GET['u'] ) or isset( $_GET['up'] ) ) {
 	// No sanitization needed here: everything happens in yourls_add_new_link()
 	if( isset( $_GET['u'] ) ) {
 		// Old school bookmarklet: ?u=<url>
-		$url = urldecode( $_GET['u'] );
+		$url = $_GET['u'];
 	} else {
 		// New style bookmarklet: ?up=<url protocol>&us=<url slashes>&ur=<url rest>
-		$url = urldecode( $_GET['up'] . $_GET['us'] . $_GET['ur'] );
+		$url = $_GET['up'] . $_GET['us'] . $_GET['ur'];
 	}
 	$keyword = ( isset( $_GET['k'] ) ? ( $_GET['k'] ) : '' );
 	$title   = ( isset( $_GET['t'] ) ? ( $_GET['t'] ) : '' );


### PR DESCRIPTION
removed urldecode() from bookmarklet $_GET requests.  $_REQUEST superglobals come decoded per https://www.php.net/manual/en/function.urldecode.php#refsect1-function.urldecode-notes

When decoded multiple times it can cause character issues, eg. removing valid '+' characters.

fixes issue  Bookmarklet strips + in long URL #3523