### PR TITLE
Fix results with 0 clicks on search

### DIFF
--- a/includes/Views/AdminParams.php
+++ b/includes/Views/AdminParams.php
@@ -222,7 +222,7 @@ class AdminParams
     public function get_click_limit()
     {
         // @hook Default link click threshold (unset)
-        return (isset($_GET['click_limit']) && intval($_GET['click_limit']) >= 0) ?
+        return (!empty($_GET['click_limit']) && intval($_GET['click_limit']) >= 0) ?
             intval($_GET['click_limit']) : yourls_apply_filter('admin_view_click_limit', '');
     }
 


### PR DESCRIPTION
There is currently a bug where the search result doesn't return entries whith 0 clicks.

When using the search on the admin page, `$_GET['click_limit']` is alwas set. It's just empty. So I check for `!empty` instead of `isset`.

It's also a possible fix to remove `=` from the check `intval($_GET['click_limit']) >= 0`.

Let me know what you think about this.