### PR TITLE
Ensure all `statusCode`/`errorCode` API values are strings

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -157,7 +157,7 @@ if ( isset( $_GET['u'] ) or isset( $_GET['up'] ) ) {
 
 				// Deal with the case when redirection failed:
 				$return['status']    = 'error';
-				$return['errorCode'] = 400;
+				$return['errorCode'] = '400';
 				$return['message']   = yourls_s( 'Short URL created, but could not redirect to %s !', 'Twitter' );
 				break;
 
@@ -168,7 +168,7 @@ if ( isset( $_GET['u'] ) or isset( $_GET['up'] ) ) {
 
 				// Deal with the case when redirection failed:
 				$return['status']    = 'error';
-				$return['errorCode'] = 400;
+				$return['errorCode'] = '400';
 				$return['message']   = yourls_s( 'Short URL created, but could not redirect to %s !', 'Facebook' );
 				break;
 
@@ -179,7 +179,7 @@ if ( isset( $_GET['u'] ) or isset( $_GET['up'] ) ) {
 
 				// Deal with the case when redirection failed:
 				$return['status']    = 'error';
-				$return['errorCode'] = 400;
+				$return['errorCode'] = '400';
 				$return['message']   = yourls_s( 'Short URL created, but could not redirect to %s !', 'Tumblr' );
 				break;
 
@@ -189,7 +189,7 @@ if ( isset( $_GET['u'] ) or isset( $_GET['up'] ) ) {
 
 				// Still here? That was an unknown 'share' method, then.
 				$return['status']    = 'error';
-				$return['errorCode'] = 400;
+				$return['errorCode'] = '400';
 				$return['message']   = yourls__( 'Unknown "Share" bookmarklet' );
 				break;
 		}

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -13,7 +13,7 @@ if( $auth !== true ) {
 		yourls_api_output( $format, array(
 			'simple' => $auth,
 			'message' => $auth,
-			'errorCode' => 403,
+			'errorCode' => '403',
 			'callback' => $callback,
 		) );
 

--- a/includes/functions-api.php
+++ b/includes/functions-api.php
@@ -183,7 +183,7 @@ function yourls_api_stats($filter = 'top', $limit = 10, $start = 0 ) {
 function yourls_api_db_stats() {
 	$return = array(
 		'db-stats'   => yourls_get_db_stats(),
-		'statusCode' => 200,
+		'statusCode' => '200',
 		'simple'     => 'Need either XML or JSON format for stats',
 		'message'    => 'success',
 	);
@@ -226,14 +226,14 @@ function yourls_api_expand( $shorturl ) {
             'title'     => yourls_get_keyword_title( $keyword ),
 			'simple'    => $longurl,
 			'message'   => 'success',
-			'statusCode' => 200,
+			'statusCode' => '200',
 		);
 	} else {
 		$return = array(
 			'keyword'   => $keyword,
 			'simple'    => 'not found',
 			'message'   => 'Error: short URL not found',
-			'errorCode' => 404,
+			'errorCode' => '404',
 		);
 	}
 

--- a/includes/functions-shorturls.php
+++ b/includes/functions-shorturls.php
@@ -143,7 +143,7 @@ function yourls_add_new_link( $url, $keyword = '', $title = '', $row_id = 1 ) {
             $return['title']    = $title;
             $return['html']     = yourls_table_add_row( $keyword, $url, $title, $ip, 0, time(), $row_id );
             $return['shorturl'] = yourls_link($keyword);
-            $return['statusCode'] = 200; // 200 OK
+            $return['statusCode'] = '200'; // 200 OK
         } else {
             // unknown database error, couldn't store result
             $return['status']   = 'fail';
@@ -595,12 +595,12 @@ function yourls_get_keyword_stats( $shorturl ) {
     if( !$res ) {
         // non existent link
         $return = array(
-            'statusCode' => 404,
+            'statusCode' => '404',
             'message'    => 'Error: short URL not found',
         );
     } else {
         $return = array(
-            'statusCode' => 200,
+            'statusCode' => '200',
             'message'    => 'success',
             'link'       => array(
                 'shorturl' => yourls_link($res->keyword),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -172,7 +172,7 @@ function yourls_get_stats($filter = 'top', $limit = 10, $start = 0) {
 
 	$return['stats'] = yourls_get_db_stats();
 
-	$return['statusCode'] = 200;
+	$return['statusCode'] = '200';
 
 	return yourls_apply_filter( 'get_stats', $return, $filter, $limit, $start );
 }

--- a/readme.html
+++ b/readme.html
@@ -504,7 +504,7 @@ echo $data->longurl;</tt></pre>
   "message": "http:\/\/ozh.org added to database",
   "title": "Ozh RICHARD \u00ab ozh.org",
   "shorturl": "http:\/\/sho.rt\/1f",
-  "statusCode": 200
+  "statusCode": "200"
 }</tt></pre>
 
             <p>Sample return in XML format for the <code>expand</code> action</p>

--- a/yourls-api.php
+++ b/yourls-api.php
@@ -35,7 +35,7 @@ foreach( (array) $api_actions as $_action => $_callback ) {
 $return = yourls_apply_filter( 'api_action_' . $action, false );
 if ( false === $return ) {
 	$return = array(
-		'errorCode' => 400,
+		'errorCode' => '400',
 		'message'   => 'Unknown or missing "action" parameter',
 		'simple'    => 'Unknown or missing "action" parameter',
 	);


### PR DESCRIPTION
PHPDoc comments about the API response format say that both `statusCode` and `errorCode` are expected to be strings, but a lot of cases were returning ints instead. This could cause problems for JSON clients.

This should resolve #3755.