### PR TITLE
Remove remaining leading slash from request

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1025,6 +1025,7 @@ function yourls_get_request($yourls_site = '', $uri = '') {
         $request = current( explode( '?', $request ) );
     }
 
+    $request = ltrim( $request, '/' );
     $request = yourls_sanitize_url( $request );
 
     return (string)yourls_apply_filter( 'get_request', $request );


### PR DESCRIPTION
I am routing yourls to a url with subfoler using reverse proxy to example.com/to so links looks like example.com/to/request

On my server:
$_SERVER[ 'REQUEST_URI' ] returns "/request"
$yourls_site equals "/to/"

yourls_get_request function returns "/request" instead of "request".

$request starts with an initial slash. 
Looks like it safe just to remove any available slash at the beginning.