### PR TITLE
update-geoip: follow redirects when downloading archive

### DIFF
--- a/.github/workflows/update-geoip.yml
+++ b/.github/workflows/update-geoip.yml
@@ -36,12 +36,12 @@ jobs:
           URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${MAXMIND_API_KEY}&suffix=tar.gz"
           REMOTE_MODIFIED=$(curl --silent --head "$URL" | grep "last-modified" | sed 's/last-modified: //')
           REMOTE_CTIME=$(date -d "$REMOTE_MODIFIED" +%s)
-          LOCAL_MODIFIED=$(curl -sL https://api.github.com/repos/YOURLS/YOURLS/commits?path=includes/geo/GeoLite2-Country.mmdb | \
+          LOCAL_MODIFIED=$(curl -fsSL https://api.github.com/repos/YOURLS/YOURLS/commits?path=includes/geo/GeoLite2-Country.mmdb | \
             jq -r '.[0]["commit"]["author"]["date"]')
           LOCAL_CTIME=$(date -d "$LOCAL_MODIFIED" +%s)
           echo "Remote: $REMOTE_CTIME ($(date -d @$REMOTE_CTIME))"
           echo "Local: $LOCAL_CTIME ($(date -d @$LOCAL_CTIME))"
-          if [ $LOCAL_CTIME -lt $REMOTE_CTIME ] ; then curl -sL "$URL" | tar -zvx -C includes/geo/ --strip-components 1 -- ; fi
+          if [ $LOCAL_CTIME -lt $REMOTE_CTIME ] ; then curl -fsSL "$URL" | tar -zvx -C includes/geo/ --strip-components 1 -- ; fi
 
       - name: "Debug info: Show git status"
         run: git status -vv --untracked=all

--- a/.github/workflows/update-geoip.yml
+++ b/.github/workflows/update-geoip.yml
@@ -41,7 +41,7 @@ jobs:
           LOCAL_CTIME=$(date -d "$LOCAL_MODIFIED" +%s)
           echo "Remote: $REMOTE_CTIME ($(date -d @$REMOTE_CTIME))"
           echo "Local: $LOCAL_CTIME ($(date -d @$LOCAL_CTIME))"
-          if [ $LOCAL_CTIME -lt $REMOTE_CTIME ] ; then curl -s "$URL" | tar -zvx -C includes/geo/ --strip-components 1 -- ; fi
+          if [ $LOCAL_CTIME -lt $REMOTE_CTIME ] ; then curl -sL "$URL" | tar -zvx -C includes/geo/ --strip-components 1 -- ; fi
 
       - name: "Debug info: Show git status"
         run: git status -vv --untracked=all


### PR DESCRIPTION
MaxMind changed some things. I remember having to investigate it for another project.

However, we can keep using the old URL format indefinitely. Just allow redirects.