### PR TITLE
Auto-skip PR auto-merge steps in update automations

### DIFF
--- a/.github/workflows/update-certificates.yml
+++ b/.github/workflows/update-certificates.yml
@@ -77,14 +77,14 @@ jobs:
             dependencies
 
       - name: Approve a PR
-        if: ${{ steps.cpr.outputs.pull-request-url && steps.cpr.outputs.pull-request-operation != 'none' }}
+        if: ${{ steps.pull-request.outputs.pull-request-url && steps.cpr.outputs.pull-request-operation != 'none' }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ steps.pull-request.outputs.pull-request-url }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Enable Pull Request Automerge
-        if: ${{ steps.cpr.outputs.pull-request-url && steps.cpr.outputs.pull-request-operation != 'none' }}
+        if: ${{ steps.pull-request.outputs.pull-request-url && steps.cpr.outputs.pull-request-operation != 'none' }}
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ steps.pull-request.outputs.pull-request-url }}

--- a/.github/workflows/update-certificates.yml
+++ b/.github/workflows/update-certificates.yml
@@ -77,12 +77,14 @@ jobs:
             dependencies
 
       - name: Approve a PR
+        if: ${{ steps.cpr.outputs.pull-request-url && steps.cpr.outputs.pull-request-operation != 'none' }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ steps.pull-request.outputs.pull-request-url }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Enable Pull Request Automerge
+        if: ${{ steps.cpr.outputs.pull-request-url && steps.cpr.outputs.pull-request-operation != 'none' }}
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ steps.pull-request.outputs.pull-request-url }}

--- a/.github/workflows/update-certificates.yml
+++ b/.github/workflows/update-certificates.yml
@@ -77,14 +77,14 @@ jobs:
             dependencies
 
       - name: Approve a PR
-        if: ${{ steps.pull-request.outputs.pull-request-url && steps.cpr.outputs.pull-request-operation != 'none' }}
+        if: ${{ steps.pull-request.outputs.pull-request-url && steps.pull-request.outputs.pull-request-operation != 'none' }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ steps.pull-request.outputs.pull-request-url }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Enable Pull Request Automerge
-        if: ${{ steps.pull-request.outputs.pull-request-url && steps.cpr.outputs.pull-request-operation != 'none' }}
+        if: ${{ steps.pull-request.outputs.pull-request-url && steps.pull-request.outputs.pull-request-operation != 'none' }}
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ steps.pull-request.outputs.pull-request-url }}

--- a/.github/workflows/update-geoip.yml
+++ b/.github/workflows/update-geoip.yml
@@ -78,12 +78,14 @@ jobs:
             dependencies
 
       - name: Approve a PR
+        if: ${{ steps.pull-request.outputs.pull-request-url && steps.pull-request.outputs.pull-request-operation != 'none' }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ steps.pull-request.outputs.pull-request-url }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Enable Pull Request Automerge
+        if: ${{ steps.pull-request.outputs.pull-request-url && steps.pull-request.outputs.pull-request-operation != 'none' }}
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ steps.pull-request.outputs.pull-request-url }}


### PR DESCRIPTION
This should stop the workflow from showing an error status when no new certificates were available for a given run, but the check ran just fine otherwise.