### PR TITLE
Add `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# End of line reformating
+3daf6593d89c608a6660a6c0b872eeb2607548ba


### PR DESCRIPTION
Should help to clean up blame even if some commits are rewriting the entire codebase.
Follow up of our discussion on https://github.com/YOURLS/YOURLS/pull/3979/files#r2356829698, this is initial stuff to try it out.

You can see it live: https://github.com/YOURLS/YOURLS/blame/feat/git-blame-ignore-revs/includes/functions-api.php
Compared to master: https://github.com/YOURLS/YOURLS/blame/master/includes/functions-api.php