### PR TITLE
Sanitize: preserve backslashes in URLs

### DIFF
--- a/includes/functions-formatting.php
+++ b/includes/functions-formatting.php
@@ -539,6 +539,18 @@ function yourls_esc_url( $url, $context = 'display', $protocols = array() ) {
     $url = yourls_normalize_uri( $url );
 
     $url = preg_replace( '|[^a-z0-9-~+_.?#=!&;,/:%@$\|*\'()\[\]\\\\\\x80-\\xff]|i', '', $url );
+    // The replace above allows backslashes now, but we only should only allow them after a query string or a fragment identifier.
+    if ( str_contains( $url, '\\') ) {
+        if ( str_contains( $url, '?') ) {
+            $parts = explode( '?', $url );
+            $url = str_replace( '\\', '', array_shift( $parts ) ) . '?' . implode( '?', $parts );
+        } elseif ( str_contains( $url, '#') ) {
+            $parts = explode( '#', $url );
+            $url = str_replace( '\\', '', array_shift( $parts ) ) . '#' . implode( '#', $parts );
+        } else {
+            $url = str_replace( '\\', '', $url );
+        }
+    }
     // Previous regexp in YOURLS was '|[^a-z0-9-~+_.?\[\]\^#=!&;,/:%@$\|*`\'<>"()\\x80-\\xff\{\}]|i'
     // TODO: check if that was it too destructive
 

--- a/tests/tests/format/URLTest.php
+++ b/tests/tests/format/URLTest.php
@@ -87,6 +87,8 @@ class URLTest extends PHPUnit\Framework\TestCase {
         yield array( 'http://%d8%b7%d8%a7%d8%b1%d9%82.net/' );
         // Backslashes should be preserved in URL fragments and queries
         yield array( 'https://example.com/path?q=a\\b\\c#x\\y\\z' );
+        yield array( 'https://example.com/path?q=a\\b\\c' );
+        yield array( 'https://example.com/path#x\\y\\z' );
         // Preserve backslashes in JSON-like fragment (regression for issue #3802)
         yield array( 'https://terminal.jcubic.pl/404#[[0,1,%22jargon%20\\%22Don%27t%20do%20that%20then!\\%22%22]]' );
     }
@@ -137,6 +139,13 @@ class URLTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals( 'http://example.com/', yourls_sanitize_url_safe( 'http://example.com/%0%0%0ADA' ) );
         $this->assertEquals( 'http://example.com/', yourls_sanitize_url_safe( 'http://example.com/%0%0%0DAd' ) );
         $this->assertEquals( 'http://example.com/', yourls_sanitize_url_safe( 'http://example.com/%0%0%0ADa' ) );
+
+        // Backslash tests
+        $this->assertEquals( 'http://example.com/', yourls_sanitize_url_safe( 'http://exa\\mple.com/' ) );
+        $this->assertEquals( 'http://example.com/testingtesting', yourls_sanitize_url_safe( 'http://example.com/testing\\testing' ) );
+        $this->assertEquals( 'http://example.com/testingtesting?query=param\\test', yourls_sanitize_url_safe( 'http://example.com/testing\\testing?query=param\\test' ) );
+        $this->assertEquals( 'http://example.com/testingtesting?query=param\\test#hash', yourls_sanitize_url_safe( 'http://example.com/testing\\testing?query=param\\test#hash' ) );
+        $this->assertEquals( 'http://example.com/testingtesting#hash\\hash', yourls_sanitize_url_safe( 'http://example.com/testing\\testing#hash\\hash' ) );
     }
 
     /**


### PR DESCRIPTION
This is a fix for #3802

This update preserves backslashes in URLs

The sample from the issue of `https://terminal.jcubic.pl/404#[[0,1,%22jargon%20\%22Don't%20do%20that%20then!\%22%22]]` now works.

Added regression tests for #3802 
Also added a test to make sure that a more generic `https://example.com/path?q=a\b\c#x\y\z` works as expected.