### PR TITLE
Add a function to get the reserved url from the global variable.

### DIFF
--- a/includes/functions-shorturls.php
+++ b/includes/functions-shorturls.php
@@ -208,17 +208,30 @@ function yourls_is_shorturl( $shorturl ) {
 }
 
 /**
+ * Get the list of reserved keywords for URLs.
+ *
+ * @return array             Array of reserved keywords
+ */
+function yourls_get_reserved_URL() {
+    global $yourls_reserved_URL;
+    if ( ! isset( $yourls_reserved_URL ) || ! is_array( $yourls_reserved_URL ) ) {
+        return array();
+    }
+
+    return $yourls_reserved_URL;
+}
+
+/**
  * Check to see if a given keyword is reserved (ie reserved URL or an existing page). Returns bool
  *
  * @param  string $keyword   Short URL keyword
  * @return bool              True if keyword reserved, false if free to be used
  */
 function yourls_keyword_is_reserved( $keyword ) {
-    global $yourls_reserved_URL;
     $keyword = yourls_sanitize_keyword( $keyword );
     $reserved = false;
 
-    if ( in_array( $keyword, $yourls_reserved_URL)
+    if ( in_array( $keyword, yourls_get_reserved_URL() )
         or yourls_is_page($keyword)
         or is_dir( YOURLS_ABSPATH ."/$keyword" )
     )

--- a/tests/tests/shorturl/ShortURLTest.php
+++ b/tests/tests/shorturl/ShortURLTest.php
@@ -9,14 +9,23 @@
 class ShortURLTest extends PHPUnit\Framework\TestCase {
 
     public function test_reserved_keywords() {
-        global $yourls_reserved_URL;
+        $yourls_reserved_URL = yourls_get_reserved_URL();
         $reserved = $yourls_reserved_URL[ array_rand( $yourls_reserved_URL, 1 )  ];
         $this->assertTrue( yourls_keyword_is_reserved( $reserved ) );
         $this->assertFalse( yourls_keyword_is_reserved( rand_str() ) );
     }
 
-    public function test_free_keywords() {
+    public function test_no_reserved_keywords() {
         global $yourls_reserved_URL;
+        $existing_keywords = $yourls_reserved_URL;
+        $yourls_reserved_URL = null;
+        $this->assertFalse( yourls_keyword_is_reserved( rand_str() ) );
+        // put it back for other tests.
+        $yourls_reserved_URL = $existing_keywords;
+    }
+
+    public function test_free_keywords() {
+        $yourls_reserved_URL = yourls_get_reserved_URL();
         $reserved = $yourls_reserved_URL[ array_rand( $yourls_reserved_URL, 1 )  ];
         $this->assertFalse( yourls_keyword_is_free( $reserved ) );
         $this->assertFalse( yourls_keyword_is_free( 'ozh' ) );


### PR DESCRIPTION
This does proper checking to make sure that it is set and is an array. This prevents errors when it is used expecting to be an array if it wasn't set properly in the config.

Also added a test to confirm that the function still works if it was set to `null`

Fixes #3769