### PR TITLE
Localization support for date and time display

### DIFF
--- a/includes/functions-html.php
+++ b/includes/functions-html.php
@@ -662,7 +662,7 @@ function yourls_table_add_row( $keyword, $url, $title, $ip, $clicks, $timestamp,
         'timestamp' => array(
             'template' => '<span class="timestamp" aria-hidden="true">%timestamp%</span> %date%',
             'timestamp' => $timestamp,
-            'date'     => yourls_date_i18n( yourls_get_datetime_format('M d, Y H:i'), yourls_get_timestamp( $timestamp )),
+            'date'     => yourls_date_i18n( yourls_get_datetime_format(yourls__('M d, Y H:i')), yourls_get_timestamp( $timestamp )),
         ),
         'ip' => array(
             'template' => '%ip%',

--- a/yourls-infos.php
+++ b/yourls-infos.php
@@ -353,7 +353,7 @@ yourls_html_menu();
                     $daysago = ' (' . sprintf( yourls_n( 'about 1 day ago', 'about %s days ago', $ago ), $ago ) . ')';
                 }
                 ?>
-                <p><?php echo /* //translators: eg Short URL created on March 23rd 1972 */ yourls_s( 'Short URL created on %s', yourls_date_i18n( yourls_get_datetime_format("F j, Y @ g:i a"), yourls_get_timestamp( $timestamp ) ) ) . $daysago; ?></p>
+                <p><?php echo /* //translators: eg Short URL created on March 23rd 1972 */ yourls_s( 'Short URL created on %s', yourls_date_i18n( yourls_get_datetime_format(yourls__("F j, Y @ g:i a")), yourls_get_timestamp( $timestamp ) ) ) . $daysago; ?></p>
                 <div class="wrap_unfloat">
                     <ul class="no_bullet toggle_display stat_line" id="historical_clicks">
                     <?php
@@ -392,7 +392,7 @@ yourls_html_menu();
                 $best_time['month'] = date( "m", strtotime( $best['day'] ) );
                 $best_time['year']  = date( "Y", strtotime( $best['day'] ) );
                 ?>
-                <p><?php echo sprintf( /* //translators: eg. 43 hits on January 1, 1970 */ yourls_n( '<strong>%1$s</strong> hit on %2$s', '<strong>%1$s</strong> hits on %2$s', $best['max'] ), $best['max'],  yourls_date_i18n( yourls_get_date_format("F j, Y"), strtotime( $best['day'] ) ) ); ?>.
+                <p><?php echo sprintf( /* //translators: eg. 43 hits on January 1, 1970 */ yourls_n( '<strong>%1$s</strong> hit on %2$s', '<strong>%1$s</strong> hits on %2$s', $best['max'] ), $best['max'],  yourls_date_i18n( yourls_get_date_format(yourls__("F j, Y")), strtotime( $best['day'] ) ) ); ?>.
                 <a href="" class='details hide-if-no-js' id="more_clicks"><?php yourls_e( 'Click for more details' ); ?></a></p>
                 <ul id="details_clicks" style="display:none">
                     <?php


### PR DESCRIPTION
This PR adds localization support for date and time display in admin interface and info pages, as requested in issue #3937. It wraps the hardcoded date format strings in yourls__() so they can be translated/customized per locale.