### PR TITLE
Notice overlapping logo in admin panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,7 +32,7 @@ a, a:link, a:active, a:visited {
 a:hover {
 	text-decoration: underline;
 }
-h1 {height:50px;margin:0;float:right;max-width:500px;}
+h1 {margin:0;float:right;max-width:500px;}
 h1 a {text-align:right;font-size:20px;float:right;}
 h1 a, h1 a:link, h1 a:active, h1 a:visited {color:#2a85b3}
 h1 a:hover{text-decoration:none;}
@@ -287,6 +287,7 @@ a.bookmarklet:hover {
 	margin-left:15%;
 	padding-left:10px;
 	margin-bottom:5px;
+	clear: both;
 }
 
 .jquery-notify-bar {


### PR DESCRIPTION
The `h1` element was using a hardcoded `height: 50px` which, combined with its `float: right`, caused `div.notice` to overlap the logo when shown after plugin activation or deactivation. Block elements do not clear floats by default, so the notice would render at the top of the collapsed header rather than below it.

Two changes made to css/style.css:

- Remove `height: 50px` from `h1` so the header height is no longer artificially constrained to a fixed value.

- Add `clear: both` to `.notice` so it always starts below any preceding floated elements, directly preventing the overlap with the logo.

Fixes #3578