### PR TITLE
Use internal links and refs for sponsors on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Do you use and enjoy YOURLS? [Become a backer](https://opencollective.com/yourls
 [![](https://opencollective.com/yourls/backer/28/avatar.svg)](https://opencollective.com/yourls/backer/28/website)
 [![](https://opencollective.com/yourls/backer/29/avatar.svg)](https://opencollective.com/yourls/backer/29/website)
 
-
 ## Sponsors
 
 Does your company use YOURLS? Ask your manager or marketing team if your company would be interested in supporting our project. Your company logo will show here. Help support our open-source development efforts by [becoming a sponsor](https://opencollective.com/yourls).
@@ -93,12 +92,11 @@ Does your company use YOURLS? Ask your manager or marketing team if your company
 [![](https://opencollective.com/yourls/sponsor/21/avatar.svg)](https://opencollective.com/yourls/sponsor/21/website)
 [![](https://opencollective.com/yourls/sponsor/22/avatar.svg)](https://opencollective.com/yourls/sponsor/22/website)
 
-#### Angel Sponsors
+### Angel Sponsors
 
-For their outstanding support to the project, we are very thankful to:
+We are very thankful to our Angel Sponsors for their outstanding support to the project.
 
-<a href="https://www.bairesdev.com/sponsoring-open-source-projects/"><img width="350px" alt="bd-logo-orange" src="https://github.com/user-attachments/assets/caa67711-33df-4974-9bbe-cd2b7356712e" /></a>
-
+[![BairesDev-LLC](https://avatars.githubusercontent.com/u/133211198?s=96&v=4)](https://github.com/BairesDev-LLC)
 
 ## License
 


### PR DESCRIPTION
See my comment on https://github.com/YOURLS/YOURLS/pull/4081/changes#r3037462973

> There has been big drama a couple of years ago about how some advertisers used fake sponsorship to gain referals and visibility.
> The outcome of this was establishing best practice on only using own cleared-platform links as much as possible (GitHub or OC in here). The fair sponsors don't need more anyway.