### PR TITLE
Improve debug functions and logic

### DIFF
--- a/includes/Config/Config.php
+++ b/includes/Config/Config.php
@@ -13,48 +13,48 @@ class Config {
     /**
      * @var string
      */
-    protected $root;
+    protected string $root;
 
     /**
      * @var string
      */
-    protected $config;
+    protected string $config;
 
     /**
      * @since  1.7.3
-     * @param  string $config   Optional user defined config path
+     * @param string $config Optional user defined config path
      */
-    public function __construct($config = '') {
-        $this->set_root( $this->fix_win32_path( dirname( dirname( __DIR__ ) ) ) );
+    public function __construct(string $config = '') {
+        $this->set_root( $this->fix_win32_path(dirname(__DIR__, 2)) );
         $this->set_config($config);
     }
 
     /**
-     * Convert antislashes to slashes
+     * Convert backslashes to slashes
      *
      * @since  1.7.3
-     * @param  string  $path
+     * @param string $path
      * @return string  path with \ converted to /
      */
-    public function fix_win32_path($path) {
+    public function fix_win32_path(string $path): string {
         return str_replace('\\', '/', $path);
     }
 
     /**
      * @since  1.7.3
-     * @param  string $config   path to config file
+     * @param string $config path to config file
      * @return void
      */
-    public function set_config($config) {
+    public function set_config(string $config): void {
         $this->config = $config;
     }
 
     /**
      * @since  1.7.3
-     * @param  string $root   path to YOURLS root directory
+     * @param string $root path to YOURLS root directory
      * @return void
      */
-    public function set_root($root) {
+    public function set_root(string $root): void {
         $this->root = $root;
     }
 
@@ -65,7 +65,7 @@ class Config {
      * @return string         path to found config file
      * @throws ConfigException
      */
-    public function find_config() {
+    public function find_config(): string {
 
         $config = $this->fix_win32_path($this->config);
 
@@ -99,7 +99,7 @@ class Config {
      * @return void
      * @throws ConfigException
      */
-    public function define_core_constants() {
+    public function define_core_constants(): void {
         // Check minimal config job has been properly done
         $must_haves = array('YOURLS_DB_USER', 'YOURLS_DB_PASS', 'YOURLS_DB_NAME', 'YOURLS_DB_HOST', 'YOURLS_DB_PREFIX', 'YOURLS_SITE');
         foreach($must_haves as $must_have) {
@@ -201,16 +201,11 @@ class Config {
         if (!defined( 'YOURLS_ADMIN_SSL' ))
             define( 'YOURLS_ADMIN_SSL', false );
 
-        // if set to true, verbose debug infos. Will break things. Don't enable.
-        if (!defined( 'YOURLS_DEBUG' ))
-            define( 'YOURLS_DEBUG', false );
-
-        // Error reporting
-        if (defined( 'YOURLS_DEBUG' ) && YOURLS_DEBUG == true ) {
-            error_reporting( -1 );
-        } else {
-            error_reporting( E_ERROR | E_PARSE );
+        // if set to true, verbose debug infos
+        if (!defined( 'YOURLS_DEBUG' )) {
+            define('YOURLS_DEBUG', false);
         }
+
     }
 
 }

--- a/includes/Database/Logger.php
+++ b/includes/Database/Logger.php
@@ -53,8 +53,10 @@ class Logger extends AbstractLogger {
         // if it's an internal SQL query, format the message, otherwise store a string
         if($level === 'query') {
             // Get the real function name that called the query (not just "perform")
-            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4);
-            $context['function'] = $backtrace[3]['function'] ?? 'perform';
+            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 6);
+            // We should have at index 5 "fetchSomething" (eg fetchAll, fetchOne, etc), otherwise make it "perform"
+            $function = $backtrace[5]['function'] ?? 'perform';
+            $context['function'] = str_starts_with($function, 'fetch') ? $function : 'perform';
             $this->messages[] = sprintf(
                 'SQL %s: %s (%s s)',
                 $context['function'],

--- a/includes/functions-debug.php
+++ b/includes/functions-debug.php
@@ -6,16 +6,19 @@
 /**
  * Add a message to the debug log
  *
- * When in debug mode (YOURLS_DEBUG == true) the debug log is echoed in yourls_html_footer()
+ * When in debug mode (YOURLS_DEBUG == true at startup or yourls_debug_mode() set to true later on), the debug log is
+ * echoed in yourls_html_footer().
  * Log messages are appended to $ydb->debug_log array, which is instantiated within class Database\YDB
  *
  * @since 1.7
  * @param string $msg Message to add to the debug log
  * @return string The message itself
  */
-function yourls_debug_log( $msg ) {
-    yourls_do_action( 'debug_log', $msg );
-    yourls_get_db('read-debug_log')->getProfiler()->getLogger()->log('debug', $msg);
+function yourls_debug_log(string $msg): string {
+    if (yourls_get_debug_mode()) {
+        yourls_do_action('debug_log', $msg);
+        yourls_get_db('read-debug_log')->getProfiler()->getLogger()->log('debug', $msg);
+    }
     return $msg;
 }
 
@@ -25,7 +28,7 @@ function yourls_debug_log( $msg ) {
  * @since  1.7.3
  * @return array
  */
-function yourls_get_debug_log() {
+function yourls_get_debug_log(): array {
     return yourls_get_db('read-get_debug_log')->getProfiler()->getLogger()->getMessages();
 }
 
@@ -34,7 +37,7 @@ function yourls_get_debug_log() {
  *
  * @return int
  */
-function yourls_get_num_queries() {
+function yourls_get_num_queries(): int {
     return yourls_apply_filter( 'get_num_queries', yourls_get_db('read-get_num_queries')->get_num_queries() );
 }
 
@@ -45,7 +48,7 @@ function yourls_get_num_queries() {
  * @param bool $bool Debug on or off
  * @return void
  */
-function yourls_debug_mode( $bool ) {
+function yourls_debug_mode(bool $bool): void {
     // log queries if true
     yourls_get_db('read-debug_mode')->getProfiler()->setActive( (bool)$bool );
 
@@ -60,6 +63,6 @@ function yourls_debug_mode( $bool ) {
  * @since 1.7.7
  * @return bool
  */
-function yourls_get_debug_mode() {
-    return defined( 'YOURLS_DEBUG' ) && YOURLS_DEBUG;
+function yourls_get_debug_mode(): bool {
+    return yourls_get_db('read-debug_mode')->getProfiler()->isActive();
 }

--- a/includes/functions-install.php
+++ b/includes/functions-install.php
@@ -199,7 +199,7 @@ function yourls_insert_with_markers( $filename, $marker, $insertion ) {
  * @since 1.3
  * @return array  An array like array( 'success' => array of success strings, 'errors' => array of error strings )
  */
-function yourls_create_sql_tables() {
+function yourls_create_sql_tables(): array {
     // Allow plugins (most likely a custom db.php layer in user dir) to short-circuit the whole function
     $pre = yourls_apply_filter( 'shunt_yourls_create_sql_tables', yourls_shunt_default() );
     // your filter function should return an array of ( 'success' => $success_msg, 'error' => $error_msg ), see below
@@ -253,6 +253,8 @@ function yourls_create_sql_tables() {
 
     $create_table_count = 0;
 
+    // Make install process verbose to help troubleshoot installation issues
+    $debug = yourls_get_debug_mode();
     yourls_debug_mode(true);
 
     // Create tables
@@ -281,6 +283,9 @@ function yourls_create_sql_tables() {
     } else {
         $error_msg[] = yourls__( 'Error creating YOURLS tables.' );
     }
+
+    // Restore debug mode to its original value
+    yourls_debug_mode( $debug );
 
     return array( 'success' => $success_msg, 'error' => $error_msg );
 }

--- a/includes/load-yourls.php
+++ b/includes/load-yourls.php
@@ -15,10 +15,19 @@ $config = new \YOURLS\Config\Config;
  * instance isn't registered.
  */
 if (!defined('YOURLS_CONFIGFILE')) {
-    define('YOURLS_CONFIGFILE', $config->find_config());
+    try {
+        define('YOURLS_CONFIGFILE', $config->find_config());
+    } catch (\YOURLS\Exceptions\ConfigException $e) {
+        die($e->getMessage());
+    }
 }
+
 require_once YOURLS_CONFIGFILE;
-$config->define_core_constants();
+try {
+    $config->define_core_constants();
+} catch (\YOURLS\Exceptions\ConfigException $e) {
+    die($e->getMessage());
+}
 
 // Initialize YOURLS with default behaviors
 

--- a/tests/tests/debug/DebugLogTest.php
+++ b/tests/tests/debug/DebugLogTest.php
@@ -6,7 +6,18 @@
 #[\PHPUnit\Framework\Attributes\Group('debug')]
 class DebugLogTest extends PHPUnit\Framework\TestCase {
 
-    public function test_debug_log_triggers_action() {
+    private bool $original_debug_mode;
+
+    protected function setUp(): void {
+        $this->original_debug_mode = yourls_get_debug_mode();
+    }
+
+    protected function tearDown(): void {
+        yourls_debug_mode($this->original_debug_mode);
+    }
+
+    public function test_debug_log_triggers_action_if_debug() {
+        yourls_debug_mode(true);
         $num_actions_before = yourls_did_action( 'debug_log' );
         $this->assertIsInt($num_actions_before);
         yourls_debug_log( 'test' );
@@ -14,16 +25,18 @@ class DebugLogTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals( $num_actions, $num_actions_before + 1);
     }
 
-    public function test_get_debug_log_is_array() {
-        $log = yourls_get_debug_log();
-        $this->assertIsArray($log);
-        $this->assertNotEmpty($log);
+    public function test_debug_log_doesnt_trigger_action_without_debug() {
+        yourls_debug_mode(false);
+        $num_actions_before = yourls_did_action( 'debug_log' );
+        $this->assertIsInt($num_actions_before);
+        yourls_debug_log( 'test' );
+        $num_actions = yourls_did_action( 'debug_log' );
+        $this->assertEquals( $num_actions, $num_actions_before);
     }
 
-    public function test_debug_log_stores_str() {
+    public function test_debug_log_stores_str_if_debug() {
+        yourls_debug_mode(true);
         $str = rand_str();
-        $log_before = yourls_get_debug_log();
-        $this->assertNotEmpty($log_before);
 
         $this->assertEquals(yourls_debug_log( $str ), $str);
         $log = yourls_get_debug_log();
@@ -32,37 +45,50 @@ class DebugLogTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals($log, $str);
     }
 
-    public function test_get_num_queries() {
-        $num = yourls_get_num_queries();
-        $this->assertIsInt($num);
-        $this->assertGreaterThan(0, $num);
+    public function test_debug_log_doesnt_store_str_without_debug() {
+        yourls_debug_mode(false);
+        $str = rand_str();
+
+        $this->assertEquals(yourls_debug_log( $str ), $str);
+        $log = yourls_get_debug_log();
+        // last entry of array $log should NOT be $str
+        $log = end($log);
+        $this->assertNotEquals($log, $str);
     }
 
-    public function test_get_debug_mode_returns_bool() {
-        $this->assertIsBool(yourls_get_debug_mode());
+    public function test_get_num_queries_if_debug() {
+        yourls_debug_mode(true);
+        $num = yourls_get_num_queries();
+        // perform dummy query
+        $str = rand_str();
+        yourls_get_db('read-test')->fetchValue("SELECT '$str'");
+        $num_after = yourls_get_num_queries();
+        // number of queries should have increased by 1
+        $this->assertEquals($num_after, $num + 1);
+        // SQL queries should be stored
+        $log = yourls_get_debug_log();
+        $this->assertStringContainsString($str, end($log));
+    }
+
+    public function test_get_num_queries_without_debug() {
+        yourls_debug_mode(false);
+        $num = yourls_get_num_queries();
+        // perform dummy query
+        $str = rand_str();
+        yourls_get_db('read-test')->fetchValue("SELECT '$str'");
+        // number of queries should have not increased and SQL queries should not be stored
+        $num_after = yourls_get_num_queries();
+        $this->assertEquals($num_after, $num);
+        $log = yourls_get_debug_log();
+        $this->assertStringNotContainsString($str, end($log));
     }
 
     public function test_debug_mode_sets_error_reporting() {
-        $debug = yourls_get_debug_mode();
-
-        $str = rand_str();
         yourls_debug_mode(true);
         $this->assertEquals( error_reporting(), -1 );
-        // SQL queries should be stored
-        yourls_get_db('read-test_rand')->fetchValue("SELECT '$str'");
-        $log = yourls_get_debug_log();
-        $this->assertStringContainsString($str, end($log));
 
-        $str = rand_str();
         yourls_debug_mode(false);
         $this->assertEquals( error_reporting(), ( E_ERROR | E_PARSE ) );
-        // SQL queries should not be stored
-        yourls_get_db('read-test_rand')->fetchValue("SELECT '$str'");
-        $log = yourls_get_debug_log();
-        $this->assertStringNotContainsString($str, end($log));
-
-        // Restore
-        yourls_debug_mode($debug);
     }
 
 }


### PR DESCRIPTION
- Fixes #4041 : make debug mode toggable, don't log anything if debug is false
- Actually logs the proper SQL function as #4064 was supposed to do
- Don't enforce debug mode when installing (eg unit tests for instance)
- Update tests
- Update coding style : from now on when I'll touch a function, I'll add return type and parameter type hints