### PR TITLE
chore(ci): pin MariaDB, cache PHPUnit, document Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+  # Composer updates are intentionally not managed by Dependabot:
+  # the vendor/ directory is committed to the repo and rebuilt with
+  # includes/vendor/build-script/yourls-build.sh after each composer
+  # update. A Dependabot PR would update composer.json/lock without
+  # running the build script, leaving vendor/ out of sync. Run
+  # `composer update --no-dev --prefer-dist` followed by the build
+  # script locally instead.
   # - package-ecosystem: composer
   #   directory: "/"
   #   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
 
     services:
       mysql:
-        image: mariadb
+        # Pinned to a MariaDB LTS line for reproducible CI; bump deliberately when upstream LTS rolls.
+        image: mariadb:11.4
         ports:
           - 3306/tcp
         env:
@@ -50,6 +51,14 @@ jobs:
         extensions: mbstring, curl, zip, dom, simplexml, intl, pdo_mysql
         tools: phpunit
         coverage: ${{ matrix.coverage }}
+
+    - name: Cache PHPUnit result cache
+      uses: actions/cache@v4
+      with:
+        path: .phpunit.cache
+        key: phpunit-${{ runner.os }}-php${{ matrix.php }}-${{ hashFiles('phpunit.xml.dist', 'tests/**/*.php') }}
+        restore-keys: |
+          phpunit-${{ runner.os }}-php${{ matrix.php }}-
 
     # - name: Validate composer.json and composer.lock
     #   run: composer validate


### PR DESCRIPTION
> [!WARNING]
> **This PR is AI-generated** (Claude Opus 4.7) on behalf of @toineenzo as part of a small modernization batch. It is intentionally kept in **draft** for now — feel free to take it over, cherry-pick, close, or just use it as a reference. No action expected from maintainers.

## Summary

Three small, low-risk hardening changes to the CI pipeline:

- **Pin MariaDB service image** to `mariadb:11.4` (the current upstream LTS line). The job currently uses an unpinned `mariadb` tag, which resolves to `latest` and can change behavior on minor releases without notice.
- **Cache the PHPUnit result cache** (`.phpunit.cache`) per-PHP-version with `actions/cache@v4`, keyed on `phpunit.xml.dist` + `tests/`. Speeds up reruns when the test set hasn't changed.
- **Document why Composer is intentionally absent from Dependabot.** The `vendor/` tree is rebuilt by `includes/vendor/build-script/yourls-build.sh` after each `composer update`; a Dependabot PR would skip that step and leave the tree out of sync. Made the existing comment explain *why* it's commented out, not just *that* it is.

Also removes `tests/includes/phpunit6-compat.php` — the file is 0 bytes and has no references anywhere in the repo.

## Test plan

- [ ] CI passes on the PR (the matrix already covers PHP 8.1 → 8.6)
- [ ] `mariadb:11.4` boots the same way the unpinned image did (same env vars, same healthcheck)
- [ ] First CI run populates the PHPUnit cache; subsequent runs hit it

## What this PR does **not** do

- No code changes to `includes/`
- No changes to the PHP matrix (already covers 8.1 → 8.6)
- No changes to release process or versioning
- No backwards-incompatible changes to plugin APIs

## Context

Part of an exploratory modernization pass. Two follow-up PRs may appear from the same fork (advisory PHPStan, release-on-tag workflow), each kept independently in draft.