### PR TITLE
chore(ci): add PHPStan as advisory job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,33 @@ jobs:
       run: phpunit --configuration phpunit.xml.dist --display-skipped --display-incomplete --display-deprecations --display-notices --display-warnings --display-errors ${{ matrix.flags }}
       env:
         DB_PORT: ${{ job.services.mysql.ports['3306'] }}
+
+  phpstan:
+    name: PHPStan (advisory)
+    runs-on: ubuntu-latest
+    # Advisory job: surfaces static-analysis findings without blocking merges.
+    # Promote to required by removing this line once the codebase is clean
+    # (or once a baseline file is committed).
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Use PHP
+      uses: shivammathur/setup-php@2.37.0
+      with:
+        php-version: '8.4'
+        extensions: mbstring, curl, zip, dom, simplexml, intl, pdo_mysql
+        tools: phpstan
+        coverage: none
+
+    - name: Cache PHPStan results
+      uses: actions/cache@v4
+      with:
+        path: .phpstan.cache
+        key: phpstan-${{ runner.os }}-${{ hashFiles('phpstan.neon.dist', 'composer.lock') }}
+        restore-keys: |
+          phpstan-${{ runner.os }}-
+
+    - name: Run PHPStan
+      run: phpstan analyse --memory-limit=1G --no-progress --error-format=github

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ coverage/
 phpunit.xml
 .phpunit.result.cache
 .phpunit.cache
+.phpstan.cache
+phpstan.neon
 tests/yourls-tests-config.php
 tests/vendor/
 tests/data/auth/config-test-auth-hashed.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,17 @@
+parameters:
+    level: 0
+    phpVersion: 80100
+    paths:
+        - admin
+        - includes
+        - yourls-loader.php
+        - yourls-go.php
+        - yourls-infos.php
+        - yourls-api.php
+    excludePaths:
+        - includes/vendor/*
+    bootstrapFiles:
+        - includes/vendor/autoload.php
+    treatPhpDocTypesAsCertain: false
+    reportUnmatchedIgnoredErrors: false
+    tmpDir: .phpstan.cache


### PR DESCRIPTION
> [!WARNING]
> **This PR is AI-generated** (Claude Opus 4.7) on behalf of @toineenzo as part of a small modernization batch. It is intentionally kept in **draft** for now — feel free to take it over, cherry-pick, close, or just use it as a reference. No action expected from maintainers.

## Summary

Adds PHPStan to CI as an **advisory** job — surfaces static-analysis findings as PR annotations without blocking merges.

- New `phpstan.neon.dist` at the repo root: level 0 (the most permissive — basic existence checks for classes, methods, functions, variables), scoped to `admin/`, `includes/`, and the top-level `yourls-*.php` entry points. `includes/vendor/*` is excluded; `phpVersion` is pinned to `80100` to match `composer.json`'s `^8.1` minimum.
- New `phpstan` job in `.github/workflows/ci.yml`, sibling to the existing `test` matrix. It uses `shivammathur/setup-php`'s `tools: phpstan` mechanism to avoid coupling with the `vendor/` build-script flow. `continue-on-error: true` keeps it advisory.
- `--error-format=github` so findings appear inline in PR review.
- `.phpstan.cache/` and a local `phpstan.neon` override file are git-ignored.

## Why level 0 / why advisory

YOURLS is largely untyped legacy code (by design — much of the plugin API depends on loose typing). Higher PHPStan levels would surface hundreds of findings that are not actionable without breaking plugins. Level 0 catches the things that are almost certainly bugs (calls to undefined functions, typos in class names, etc.) without requiring type annotations.

The job is advisory because:
1. No baseline is committed in this PR — I don't have a PHP environment to generate one against this exact tree.
2. Maintainers should decide whether to enforce, generate a baseline, or raise the level — that's a call for you, not for an outside contributor to make unilaterally.

## Test plan

- [ ] PHPStan runs successfully on PR (job appears, doesn't crash)
- [ ] Findings (if any) appear as inline annotations in the PR Files tab
- [ ] The job does not block merging

## How to promote later

Once you're comfortable with the findings:

1. Locally: \`vendor/bin/phpstan analyse --generate-baseline phpstan-baseline.neon\`
2. Add \`includes:\n    - phpstan-baseline.neon\` to \`phpstan.neon.dist\`
3. Remove \`continue-on-error: true\` from the job

## What this PR does **not** do

- No code changes to \`includes/\`, \`admin/\`, or any source file
- No changes to runtime behavior
- No changes to \`composer.json\` (PHPStan is not added as a dev dep)
- No baseline committed (intentional — see above)
- No higher PHPStan level (intentional — see above)

## Context

Part of an exploratory modernization pass. Sibling PR: #4095 (CI hardening). One more may follow (release-on-tag workflow). Each kept independently in draft.