### PR TITLE
feat(ci): draft a GitHub Release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,164 @@
+name: Release on tag
+
+on:
+  push:
+    tags:
+      # GitHub Actions tag filters use fnmatch (no regex quantifiers).
+      # These cover 2- and 3-component versions: 1.8, 1.10.3, etc.
+      # Pre-release suffixes (e.g. 1.10.3-rc1) match the second pattern;
+      # the workflow tolerates that and produces a draft for review.
+      - '[0-9]*.[0-9]*'
+      - '[0-9]*.[0-9]*.[0-9]*'
+  # Allow re-running for an existing tag if the changelog was updated late.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to (re)build a draft release for'
+        required: true
+
+permissions:
+  contents: write
+
+# Cancel an in-flight run for the same tag if a newer run is queued.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  draft-release:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    # Don't run on forks; the upstream repo is the source of truth for releases.
+    if: github.repository == 'YOURLS/YOURLS'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Need full history so we can find the previous tag for the compare link.
+          fetch-depth: 0
+
+      - name: Determine tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          TAG="${INPUT_TAG:-$REF_NAME}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag: $TAG"
+
+      - name: Skip if a non-draft release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          # Idempotent: don't fight a release the maintainer already published.
+          # A draft release with the same tag is fine — it will be replaced.
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' 2>/dev/null | grep -q '^false$'; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Published release for $TAG already exists; skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract CHANGELOG section
+        if: steps.check.outputs.exists == 'false'
+        id: changelog
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          # Pull lines between the `<TAG>` header and the next version header.
+          # CHANGELOG format:
+          #   1.10.3
+          #   ---
+          #   - added: ...
+          #
+          #   1.10.2
+          #   ---
+          SECTION=$(awk -v tag="$TAG" '
+            $0 == tag                                              { found=1; next }
+            found && /^---+$/                                      { next }
+            found && /^[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9.]+)?$/ { exit }
+            found                                                  { print }
+          ' CHANGELOG.md | sed -e 's/[[:space:]]*$//')
+
+          if [ -z "$(printf '%s' "$SECTION" | tr -d '[:space:]')" ]; then
+            echo "::warning::No CHANGELOG section found for tag $TAG. Draft will be created with a placeholder body."
+            SECTION="_(No CHANGELOG entry found for \`$TAG\`. Update CHANGELOG.md and re-run via workflow_dispatch.)_"
+          fi
+
+          {
+            echo 'section<<CHANGELOG_EOF'
+            printf '%s\n' "$SECTION"
+            echo 'CHANGELOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find previous tag for compare link
+        if: steps.check.outputs.exists == 'false'
+        id: prev
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          # Highest version-sorted tag that is not the current one and not a pre-release.
+          PREV=$(git tag --list --sort=-v:refname \
+            | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' \
+            | grep -v "^${TAG}$" \
+            | head -1 || true)
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${PREV:-<none>}"
+
+      - name: Compose release body
+        if: steps.check.outputs.exists == 'false'
+        id: body
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          SECTION: ${{ steps.changelog.outputs.section }}
+          PREV: ${{ steps.prev.outputs.prev }}
+        run: |
+          {
+            echo 'body<<BODY_EOF'
+            echo "## YOURLS **$TAG**"
+            echo
+            echo "### What's Changed"
+            echo
+            printf '%s\n' "$SECTION"
+            if [ -n "$PREV" ]; then
+              echo
+              echo "**Full Changelog**: https://github.com/$GITHUB_REPOSITORY/compare/$PREV...$TAG"
+            fi
+            echo
+            echo "### How to install or update"
+            echo
+            echo "Download the source code below and upload to your server."
+            echo "We recommend to back up your DB before any update."
+            echo
+            echo "More detailed instructions available on https://yourls.org/docs/"
+            echo
+            echo "### Shorten your links and make YOURLS bigger!"
+            echo
+            echo "Does your company use YOURLS? Help the project, become a sponsor and get your logo on our README on GitHub with a link to your site. [Become a sponsor](https://yourls.org/sponsor/)."
+            echo 'BODY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or replace draft release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          BODY: ${{ steps.body.outputs.body }}
+        run: |
+          # Delete any existing draft for this tag before recreating.
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' 2>/dev/null | grep -q '^true$'; then
+            echo "Deleting existing draft for $TAG"
+            gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes
+          fi
+
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
+            --notes "$BODY" \
+            --draft
+
+          echo "::notice::Draft release created for $TAG. Review and publish at https://github.com/$GITHUB_REPOSITORY/releases"


### PR DESCRIPTION
> [!WARNING]
> **This PR is AI-generated** (Claude Opus 4.7) on behalf of @toineenzo as part of a small modernization batch. It is intentionally kept in **draft** for now — feel free to take it over, cherry-pick, close, or just use it as a reference. No action expected from maintainers.

## Summary

Adds `.github/workflows/release.yml` that automates the **drafting** step of a release. Publish remains a manual click in the GitHub Releases UI — this workflow never publishes anything.

Each release today appears to be hand-built by a maintainer copy-pasting the relevant `CHANGELOG.md` section into a new GitHub Release (last release `1.10.3` follows that pattern). This workflow takes that mechanical step off the maintainer's plate.

## Behavior

- **Trigger**: push of a 2- or 3-component version tag (`1.8`, `1.10.3`). Pre-release suffixes like `1.10.3-rc1` match too; the workflow tolerates them and produces a draft for review. Also exposes `workflow_dispatch` with a `tag` input for re-runs after a late CHANGELOG edit.
- **Idempotent**: skips if a **non-draft** release already exists for the tag, so a re-run never clobbers something already published. Replaces an existing **draft** release (so a re-run after a CHANGELOG fix gets fresh content).
- **CHANGELOG-driven**: extracts the section between the version header and the next version header, formatted into the same shape used in past releases:
  - `## YOURLS **<tag>**`
  - `### What's Changed`
  - `**Full Changelog**: <prev>...<tag>` compare link (auto-resolved from `git tag --sort=-v:refname`)
  - `### How to install or update` boilerplate
  - `### Shorten your links and make YOURLS bigger!` sponsor footer
- **Fork-safe**: gated on `github.repository == 'YOURLS/YOURLS'` so contributor forks pushing their own tags don't trigger spurious releases.
- **Permissions**: `contents: write` only — no PR write, no actions write.

## Test plan

- [ ] Tag `1.10.4` (when ready): workflow runs, draft release appears under Releases → Drafts with the CHANGELOG section already filled in
- [ ] If CHANGELOG section is missing for the tag: draft is still created, with a placeholder body and a CI warning
- [ ] If a published release for the tag already exists: workflow skips, emits a notice
- [ ] If a draft already exists: workflow deletes and recreates it
- [ ] `workflow_dispatch` with manual tag input works the same way

## What this PR does **not** do

- Does **not** publish anything — every release stays a draft for manual review/edit/publish
- Does **not** change the existing manual flow — maintainers can still create releases by hand and this workflow will not interfere (skip-if-published)
- Does **not** change tag conventions, version numbering, or CHANGELOG format
- Does **not** auto-attach assets — relies on GitHub's automatic source-code archives (matches current behavior)
- Does **not** generate "New Contributors" or auto-PR-list sections — that's GitHub's `--generate-notes`, which would duplicate the CHANGELOG content. The maintainer can still add it manually before publishing if desired.

## Context

Part of an exploratory modernization pass. Sibling PRs: #4095 (CI hardening), #4096 (PHPStan advisory). Each kept independently in draft.