### PR TITLE
Make tests debugging easier

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.0/phpunit.xsd"
     backupGlobals="false"
     stopOnFailure="true"
     cacheDirectory=".phpunit.cache"
@@ -13,7 +13,10 @@
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
     displayDetailsOnPhpunitDeprecations="true"
-    >
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnPhpunitNotices="true"
+    displayDetailsOnSkippedTests="true"
+>
     <source>
         <include>
             <directory suffix=".php">./includes</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,6 @@
     displayDetailsOnTestsThatTriggerWarnings="true"
     displayDetailsOnPhpunitDeprecations="true"
     displayDetailsOnIncompleteTests="true"
-    displayDetailsOnPhpunitNotices="true"
     displayDetailsOnSkippedTests="true"
 >
     <source>

--- a/tests/tests/auth/AuthTest.php
+++ b/tests/tests/auth/AuthTest.php
@@ -176,9 +176,15 @@ class AuthTest extends PHPUnit\Framework\TestCase {
      * Check that encrypting un-writable file returns expected error
      */
     public function test_hash_passwords_now_unwritable() {
+        // If running as root, skip test since file permissions are not enforced
+        if (function_exists('posix_getuid') && posix_getuid() === 0) {
+            $this->markTestSkipped('Running as root, file permissions are not enforced');
+        }
         // generate un-writable file
         $file = YOURLS_TESTDATA_DIR . '/auth/unwritable.php';
-        touch( $file );
+        if(touch( $file ) === false) {
+            $this->markTestSkipped("Could not create $file -- cannot run test");
+        }
 
         if(yourls_is_windows()) {
             exec( 'attrib +r ' . escapeshellarg( $file ) );

--- a/tests/tests/auth/LoginAssertionTrait.php
+++ b/tests/tests/auth/LoginAssertionTrait.php
@@ -12,7 +12,7 @@ trait LoginAssertionTrait
         $login        = yourls_did_action( 'login' );
         $login_failed = yourls_did_action( 'login_failed' );
 
-        $this->assertTrue( yourls_is_valid_user() );
+        $this->assertTrue( yourls_is_valid_user(), sprintf('Could not auth with %s/%s', $_REQUEST['username'], $_REQUEST['password'] ) );
 
         $this->assertEquals( $pre_login + 1, yourls_did_action( 'pre_login' ) );
         $this->assertEquals( $login + 1, yourls_did_action( 'login' ) );

--- a/tests/tests/auth/LogoutTest.php
+++ b/tests/tests/auth/LogoutTest.php
@@ -36,8 +36,7 @@ class LogoutTest extends PHPUnit\Framework\TestCase {
      */
     public function test_logout_user_is_logged_in() {
         $_REQUEST['nonce'] = yourls_create_nonce('admin_login');
-        $valid = yourls_is_valid_user();
-        $this->assertTrue($valid);
+        $this->assertTrue(yourls_is_valid_user(), sprintf('Could not auth with %s/%s', $_REQUEST['username'], $_REQUEST['password'] ));
         $this->assertSame('yourls', self::$user);
     }
 

--- a/tests/tests/auth/RedirectionTest.php
+++ b/tests/tests/auth/RedirectionTest.php
@@ -27,7 +27,7 @@ class RedirectionTest extends PHPUnit\Framework\TestCase {
     public function test_login() {
         $_REQUEST['nonce'] = yourls_create_nonce('admin_login');
         $_SERVER['REQUEST_URI'] = '/';
-        $this->assertSame( 3, yourls_is_valid_user() );
+        $this->assertSame( 3, yourls_is_valid_user(), sprintf('Could not auth with %s/%s', $_REQUEST['username'], $_REQUEST['password'] ) );
     }
 
 }


### PR DESCRIPTION
This trivial PR facilitates some reports on failing tests.

I recently encountered 2 situations that had me pulling some hair

* `$_REQUEST` not being populated according to `phpunit.xml.dist` -- it has something to do with code coverage in the `uses: shivammathur/setup-php` step. I didn't dig too far but anyway this PR helps troubleshooting that, by displaying what login/password are used when auth tests fail
* if running apache under root, config hashing tests were failing because they rely on file permissions, which root doesn't care about. This PR marks relevant tests as skipped with a meaningful message

I also udpated the `phpunit.xml.dist` to display everything useful it can without having to mention `--display-skipped --display-incomplete --display-deprecations --display-notices --display-warnings --display-errors`, so people running PHPUnit at home get closest results to what we have here on Github