### PR TITLE
Prevent XSS in stat pages through referrers

### DIFF
--- a/includes/functions-infos.php
+++ b/includes/functions-infos.php
@@ -38,8 +38,8 @@ function yourls_stats_countries_map($countries, $id = null) {
  *
  * @param array $data  Array of 'data' => 'value'
  * @param int $limit   Optional limit list of X first countries
- * @param $size        Optional size of the image
- * @param $id          Optional HTML element ID
+ * @param int $size    Optional size of the image
+ * @param mixed $id    Optional HTML element ID
  * @return void
  */
 function yourls_stats_pie($data, $limit = 10, $size = '340x220', $id = null) {
@@ -253,18 +253,43 @@ function yourls_stats_get_best_day($list_of_days) {
  * @param bool $include_scheme
  * @return string
  */
-function yourls_get_domain($url, $include_scheme = false) {
-    $parse = @parse_url( $url ); // Hiding ugly stuff coming from malformed referrer URLs
+function yourls_get_domain(string $url, bool $include_scheme = false): string {
+    $parse = parse_url($url);
+
+    // parse_url() returns false on seriously malformed URLs
+    if ($parse === false) {
+        return '';
+    }
 
     // Get host & scheme. Fall back to path if not found.
-    $host = isset( $parse['host'] ) ? $parse['host'] : '';
-    $scheme = isset( $parse['scheme'] ) ? $parse['scheme'] : '';
-    $path = isset( $parse['path'] ) ? $parse['path'] : '';
-    if( !$host )
+    $host = $parse['host'] ?? '';
+    $scheme = $parse['scheme'] ?? '';
+    $path = $parse['path'] ?? '';
+    if (!$host) {
         $host = $path;
+    }
 
-    if ( $include_scheme && $scheme )
-        $host = $scheme.'://'.$host;
+    // Validate host: only allow valid hostname/IP characters.
+    // IPv6 addresses are wrapped in brackets eg [::1]
+    if ($host && !preg_match('/^(\[[\da-fA-F:]+\]|[a-zA-Z0-9._-]+)$/', $host)) {
+        // ASCII check failed - may be an IDN hostname (eg münchen.de)
+        if (function_exists('idn_to_ascii')) {
+            $ascii = idn_to_ascii($host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+            if ($ascii === false || !preg_match('/^[a-zA-Z0-9._-]+$/', $ascii)) {
+                return '';
+            }
+            $host = $ascii;
+        } else {
+            // No intl extension: accept unicode letters/digits, dots and hyphens only
+            if (!preg_match('/^[\pL\pN._-]+$/u', $host)) {
+                return '';
+            }
+        }
+    }
+
+    if ($include_scheme && $scheme) {
+        $host = $scheme . '://' . $host;
+    }
 
     return $host;
 }
@@ -276,8 +301,8 @@ function yourls_get_domain($url, $include_scheme = false) {
  * @param string $url
  * @return string
  */
-function yourls_get_favicon_url($url) {
-    return yourls_match_current_protocol( '//www.google.com/s2/favicons?domain=' . yourls_get_domain( $url, false ) );
+function yourls_get_favicon_url(string $url): string {
+    return yourls_match_current_protocol( '//www.google.com/s2/favicons?domain=' . yourls_esc_url(yourls_get_domain( $url, false ) ) );
 }
 
 /**
@@ -335,16 +360,17 @@ function yourls_array_granularity($array, $grain = 100, $preserve_max = true) {
  * @param array $data
  * @return string
  */
-function yourls_google_array_to_data_table($data){
+function yourls_google_array_to_data_table(array $data): string {
     $str  = "var data = google.visualization.arrayToDataTable([\n";
     foreach( $data as $label => $values ){
         if( !is_array( $values ) ) {
             $values = array( $values );
         }
-        $str .= "\t['$label',";
+        $str .= "\t['" . yourls_esc_js($label) . "',";
         foreach( $values as $value ){
-            if( !is_numeric( $value ) && strpos( $value, '[' ) !== 0 && strpos( $value, '{' ) !== 0 ) {
-                $value = "'$value'";
+            $value = yourls_esc_url( $value );
+            if( !is_numeric( $value ) && !str_starts_with($value, '[') && !str_starts_with($value, '{')) {
+                $value = "'" . yourls_esc_js($value) . "'";
             }
             $str .= "$value";
         }
@@ -360,7 +386,7 @@ function yourls_google_array_to_data_table($data){
  *
  * @param string $graph_type
  * @param string $data
- * @param var $options
+ * @param array  $options
  * @param string $id
  * @return string
  */

--- a/tests/tests/format/URLTest.php
+++ b/tests/tests/format/URLTest.php
@@ -317,4 +317,67 @@ class URLTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals( yourls_sanitize_url($url), $expected );
     }
 
+    /**
+     * List of URLs to test yourls_get_domain(). Structure: [URL, include_scheme, expected_result]
+     */
+    static function list_of_get_domain(): \Iterator {
+        // Standard well-formed URLs: only host returned
+        yield [ 'http://example.com',                     false, 'example.com'      ];
+        yield [ 'http://example.com/',                    false, 'example.com'      ];
+        yield [ 'http://example.com/path?q=1#frag',       false, 'example.com'      ];
+        yield [ 'https://sub.example.com/path',           false, 'sub.example.com'  ];
+
+        // include_scheme=true: scheme:// is prepended
+        yield [ 'http://example.com',                     true,  'http://example.com'  ];
+        yield [ 'https://example.com/',                   true,  'https://example.com' ];
+
+        // Credentials and port are excluded from the returned domain
+        yield [ 'http://user:pass@example.com/',          false, 'example.com'      ];
+        yield [ 'http://example.com:8080/path',           false, 'example.com'      ];
+
+        // IPv4 address
+        yield [ 'http://192.168.1.1/',                    false, '192.168.1.1'      ];
+
+        // No scheme: parse_url returns it as path, function falls back to using path as host
+        yield [ 'example.com',                            false, 'example.com'      ];
+        // No scheme + include_scheme=true: scheme is empty so nothing is prepended
+        yield [ 'example.com',                            true,  'example.com'      ];
+
+        // Protocol-relative URL: host is parsed but scheme is absent
+        yield [ '//example.com/path',                     false, 'example.com'      ];
+        yield [ '//example.com/path',                     true,  'example.com'      ];
+
+        // IDN domain: returns ASCII punycode if idn_to_ascii() is available, unicode otherwise
+        yield [ 'http://münchen.de/',                     false, function_exists('idn_to_ascii') ? 'xn--mnchen-3ya.de' : 'münchen.de' ];
+        yield [ 'http://münchen.de/',                     true,  function_exists('idn_to_ascii') ? 'http://xn--mnchen-3ya.de' : 'http://münchen.de' ];
+        yield [ 'http://www.طارق.net/',                  false, function_exists('idn_to_ascii') ? 'www.xn--mgbuq0c.net' : 'www.طارق.net' ];
+
+        // Empty string and no host: return empty
+        yield [ '',                                       false, '' ];
+        yield [ 'http://',                                false, '' ];
+
+        // Bogus inputs: host position contains chars that fail the hostname regex
+        yield [ 'not a valid url',                        false, '' ]; // spaces in host fallback
+        yield [ 'javascript:alert(1)',                    false, '' ]; // parentheses from path-as-host
+        yield [ 'http://<script>alert(1)</script>/',      false, '' ]; // angle brackets in host
+        yield [ 'http://<script>alert(1)</script>/',      true,  '' ]; // same with include_scheme=true
+
+        // data: URI: path used as host, slash and comma fail regex
+        yield [ 'data:text/html,<h1>xss</h1>',           false, '' ];
+
+        // Null byte in host (percent-encoded): % is not in [a-zA-Z0-9._-]
+        yield [ 'http://evil.com%00.example.com/',        false, '' ];
+
+        // Host that is only invalid characters
+        yield [ 'http://!@#$%^&*()/path',                 false, '' ];
+    }
+
+    /**
+     * Test yourls_get_domain() against well-formed, IDN, bogus and exploit-attempt URLs
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('list_of_get_domain')]
+    function test_get_domain( $url, $include_scheme, $expected ) {
+        $this->assertSame( $expected, yourls_get_domain( $url, $include_scheme ) );
+    }
+
 }


### PR DESCRIPTION
Fix potential XSS as described [here](https://github.com/YOURLS/YOURLS/security/advisories/GHSA-5h77-88j3-r659) 

* JS data used to generate the graph is handled with `yourls_esc_js()` as it should have been
* A few more sanitization while I was there, with `yourls_get_favicon_url()` and `yourls_get_domain()` to output better HTML
* Minor coding style update limited to the functions I've updated (return type, etc)