### PR TITLE
Implement cookie prefixes

### DIFF
--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -451,7 +451,7 @@ function yourls_check_timestamp( $time ) {
  * @param string $user  User login, or empty string to delete cookie
  * @return void
  */
-function yourls_store_cookie( $user = '' ) {
+function yourls_store_cookie(string $user = '' ): void {
 
     // No user will delete the cookie with a cookie time from the past
     if( !$user ) {
@@ -460,14 +460,11 @@ function yourls_store_cookie( $user = '' ) {
         $time = time() + yourls_get_cookie_life();
     }
 
-    $path     = yourls_apply_filter( 'setcookie_path',     '/' );
-    $domain   = yourls_apply_filter( 'setcookie_domain',   parse_url( yourls_get_yourls_site(), PHP_URL_HOST ) );
-    $secure   = yourls_apply_filter( 'setcookie_secure',   yourls_is_ssl() );
-    $httponly = yourls_apply_filter( 'setcookie_httponly', true );
-
-    // Some browsers refuse to store localhost cookie
-    if ( $domain == 'localhost' )
-        $domain = '';
+    $attr     = yourls_cookie_attributes();
+    $path     = $attr['path'];
+    $domain   = $attr['domain'];
+    $secure   = $attr['secure'];
+    $httponly = $attr['httponly'];
 
     yourls_do_action( 'pre_setcookie', $user, $time, $path, $domain, $secure, $httponly );
 
@@ -508,6 +505,66 @@ function yourls_setcookie($name, $value, $expire, $path, $domain, $secure, $http
         'secure'   => $secure,
         'httponly' => $httponly,
     )));
+}
+
+/**
+ * Get auth cookie attributes after filters
+ *
+ * Single source of truth used both when storing the cookie and when deriving the
+ * cookie name prefix in yourls_cookie_name_prefix(). This guarantees the prefix
+ * matches the attributes actually sent: otherwise the browser silently rejects
+ * the Set-Cookie and breaks login.
+ *
+ * @since 1.10.5
+ * @return array  Associative array with keys 'path', 'domain', 'secure', 'httponly'
+ */
+function yourls_cookie_attributes(): array {
+    // Cast to string so a null/false return from parse_url normalises to '' and the
+    // __Host- check below stays deterministic
+    $domain = (string) yourls_apply_filter( 'setcookie_domain', parse_url( yourls_get_yourls_site(), PHP_URL_HOST ) );
+
+    // Some browsers refuse to store localhost cookie
+    if ( $domain === 'localhost' ) {
+        $domain = '';
+    }
+
+    return array(
+        'path'     => yourls_apply_filter( 'setcookie_path',     '/' ),
+        'domain'   => $domain,
+        'secure'   => yourls_apply_filter( 'setcookie_secure',   yourls_is_ssl() ),
+        'httponly' => yourls_apply_filter( 'setcookie_httponly', true ),
+    );
+}
+
+/**
+ * Get the cookie name prefix matching the current cookie attributes
+ *
+ * Picks the strongest RFC 6265bis prefix the attributes allow, since both prefixes
+ * are mutually exclusive (a cookie has one name):
+ *   __Host-   : requires Secure + Path=/ + no Domain attribute (host-only cookie).
+ *               On HTTPS, retires the #1673 cross-subdomain concern at the browser
+ *               level: the cookie cannot leak to nor be set by sibling subdomains.
+ *   __Secure- : requires Secure only. Used when a Domain attribute is set, or when
+ *               the cookie path is not '/'. Blocks Set-Cookie from insecure channels.
+ *   ''        : on HTTP installs, no prefix is possible: the browser would reject
+ *               any prefixed cookie that lacks the Secure attribute.
+ *
+ * @since 1.10.5
+ * @return string  '__Host-', '__Secure-' or '' depending on cookie attributes
+ */
+function yourls_cookie_name_prefix(): string {
+    $attr = yourls_cookie_attributes();
+
+    // HTTP: browser would reject any prefixed cookie
+    if ( !$attr['secure'] ) {
+        return '';
+    }
+    // Strongest: host-only at root path
+    if ( $attr['domain'] === '' && $attr['path'] === '/' ) {
+        return '__Host-';
+    }
+    // Fallback: a Domain is set or path is not '/'
+    return '__Secure-';
 }
 
 /**
@@ -553,15 +610,21 @@ function yourls_get_nonce_life() {
 /**
  * Get YOURLS cookie name
  *
- * The name is unique for each install, to prevent mismatch between sho.rt and very.sho.rt -- see #1673
+ * The base name is unique per install (salt of the site URL) to prevent collision between eg sho.rt
+ * and very.sho.rt - see #1673.
+ * On HTTPS, the name is additionally prefixed with __Host- or __Secure- to enable browser-side
+ * hardening against cookie injection over insecure channels and, for __Host-, cross-subdomain reads or writes.
+ * See #2785
  *
  * TODO: when multi user is implemented, the whole cookie stuff should be reworked to allow storing multiple users
  *
  * @since 1.7.1
  * @return string  unique cookie name for a given YOURLS site
  */
-function yourls_cookie_name() {
-    return yourls_apply_filter( 'cookie_name', 'yourls_' . yourls_salt( yourls_get_yourls_site() ) );
+function yourls_cookie_name(): string {
+    $name = yourls_cookie_name_prefix() . 'yourls_' . yourls_salt( yourls_get_yourls_site() );
+
+    return yourls_apply_filter( 'cookie_name', $name );
 }
 
 /**

--- a/tests/tests/auth/LoginCookieTest.php
+++ b/tests/tests/auth/LoginCookieTest.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * Login tests - via Cookies
- *
- * @since 0.1
+ * Login tests - via Cookies - and cookie functions tests
  */
 #[\PHPUnit\Framework\Attributes\Group('auth')]
 #[\PHPUnit\Framework\Attributes\Group('login')]
@@ -12,6 +10,8 @@ class LoginCookieTest extends PHPUnit\Framework\TestCase {
     protected $cookie;
     protected $request;
     protected $backup_yourls_actions;
+
+    protected $added_filters = [];
 
     protected function setUp(): void {
         $this->cookie = $_COOKIE;
@@ -25,6 +25,28 @@ class LoginCookieTest extends PHPUnit\Framework\TestCase {
         $_REQUEST = $this->request;
         global $yourls_actions;
         $yourls_actions = $this->backup_yourls_actions;
+
+        foreach ( $this->added_filters as $filter ) {
+            yourls_remove_filter( $filter[0], $filter[1] );
+        }
+        $this->added_filters = [];
+    }
+
+    /**
+     * Add a filter and register it for automatic removal in tearDown()
+     */
+    protected function add_filter( string $hook, $callback ): void {
+        yourls_add_filter( $hook, $callback );
+        $this->added_filters[] = [ $hook, $callback ];
+    }
+
+    /**
+     * Add an action and register it for automatic removal in tearDown()
+     * (actions are stored alongside filters, so yourls_remove_filter() works)
+     */
+    protected function add_action( string $hook, $callback ): void {
+        yourls_add_action( $hook, $callback );
+        $this->added_filters[] = [ $hook, $callback ];
     }
 
     public static function setUpBeforeClass(): void {
@@ -50,10 +72,182 @@ class LoginCookieTest extends PHPUnit\Framework\TestCase {
     }
 
     /**
+     * Check that the cookie value is filterable
+     */
+    public function test_cookie_value_is_filtered() {
+        $this->add_filter( 'set_cookie_value', function() { return 'filtered_cookie_value'; } );
+        $this->assertSame( 'filtered_cookie_value', yourls_cookie_value( rand_str() ) );
+    }
+
+    /**
      * Check for valid cookie life
      */
     public function test_cookie_life() {
         $this->assertTrue( is_int(yourls_get_cookie_life()) );
+    }
+
+    /**
+     * Check that the cookie name is filterable
+     */
+    public function test_cookie_name_is_filtered() {
+        $this->add_filter( 'cookie_name', function() { return 'my_custom_cookie_name'; } );
+        $this->assertSame( 'my_custom_cookie_name', yourls_cookie_name() );
+    }
+
+    /**
+     * Cookie attributes : returns the expected structure
+     */
+    public function test_cookie_attributes_structure() {
+        $attr = yourls_cookie_attributes();
+
+        $this->assertIsArray( $attr );
+        $this->assertArrayHasKey( 'path',     $attr );
+        $this->assertArrayHasKey( 'domain',   $attr );
+        $this->assertArrayHasKey( 'secure',   $attr );
+        $this->assertArrayHasKey( 'httponly', $attr );
+
+        $this->assertIsString( $attr['path'] );
+        $this->assertIsString( $attr['domain'] );
+        $this->assertIsBool( $attr['secure'] );
+        $this->assertIsBool( $attr['httponly'] );
+    }
+
+    /**
+     * Cookie attributes : default values
+     */
+    public function test_cookie_attributes_defaults() {
+        $attr = yourls_cookie_attributes();
+
+        $this->assertSame( '/', $attr['path'] );
+        $this->assertTrue( $attr['httponly'] );
+    }
+
+    /**
+     * Cookie attributes : 'secure' follows yourls_is_ssl()
+     */
+    public function test_cookie_attributes_secure_follows_ssl() {
+        $this->add_filter( 'is_ssl', 'yourls_return_true' );
+        $this->assertTrue( yourls_cookie_attributes()['secure'] );
+    }
+
+    public function test_cookie_attributes_not_secure_without_ssl() {
+        $this->add_filter( 'is_ssl', 'yourls_return_false' );
+        $this->assertFalse( yourls_cookie_attributes()['secure'] );
+    }
+
+    /**
+     * Cookie attributes : 'secure' can be forced regardless of SSL.
+     * On top of being tested to make sure that feature will not get removed from the code, this is also used
+     * here in unit tests.
+     */
+    public function test_cookie_attributes_secure_is_filtered() {
+        // SSL off, but secure forced on
+        $this->add_filter( 'is_ssl', 'yourls_return_false' );
+        $this->add_filter( 'setcookie_secure', 'yourls_return_true' );
+        $this->assertTrue( yourls_cookie_attributes()['secure'] );
+    }
+
+    /**
+     * Cookie attributes : path, domain and httponly are filterable
+     * On top of being tested to make sure that feature will not get removed from the code, this is also used
+     * here in unit tests.
+     */
+    public function test_cookie_attributes_are_filtered() {
+        $this->add_filter( 'setcookie_path',     function() { return '/sub/'; } );
+        $this->add_filter( 'setcookie_domain',   function() { return 'sho.rt'; } );
+        $this->add_filter( 'setcookie_httponly', 'yourls_return_false' );
+
+        $attr = yourls_cookie_attributes();
+
+        $this->assertSame( '/sub/', $attr['path'] );
+        $this->assertSame( 'sho.rt', $attr['domain'] );
+        $this->assertFalse( $attr['httponly'] );
+    }
+
+    /**
+     * Cookie attributes : a 'localhost' domain is normalized to an empty string
+     */
+    public function test_cookie_attributes_localhost_domain_is_emptied() {
+        $this->add_filter( 'setcookie_domain', function() { return 'localhost'; } );
+        $this->assertSame( '', yourls_cookie_attributes()['domain'] );
+    }
+
+    /**
+     * Cookie attributes : a null/false domain is normalized to an empty string
+     */
+    public function test_cookie_attributes_null_domain_is_emptied() {
+        $this->add_filter( 'setcookie_domain', 'yourls_return_false' );
+        $this->assertSame( '', yourls_cookie_attributes()['domain'] );
+    }
+
+    /**
+     * Cookie name prefix : no prefix on a non-secure (HTTP) install
+     */
+    public function test_cookie_name_prefix_empty_when_not_secure() {
+        $this->add_filter( 'is_ssl', 'yourls_return_false' );
+        $this->assertSame( '', yourls_cookie_name_prefix() );
+    }
+
+    /**
+     * Cookie name prefix : __Host- when Secure + host-only (no Domain) + Path=/
+     */
+    public function test_cookie_name_prefix_host_when_secure_hostonly_rootpath() {
+        $this->add_filter( 'is_ssl', 'yourls_return_true' );
+        $this->add_filter( 'setcookie_domain', function() { return ''; } );
+        // path defaults to '/'
+        $this->assertSame( '__Host-', yourls_cookie_name_prefix() );
+    }
+
+    /**
+     * Cookie name prefix : __Secure- when Secure but a Domain attribute is set
+     */
+    public function test_cookie_name_prefix_secure_when_domain_is_set() {
+        $this->add_filter( 'is_ssl', 'yourls_return_true' );
+        $this->add_filter( 'setcookie_domain', function() { return 'sho.rt'; } );
+        $this->assertSame( '__Secure-', yourls_cookie_name_prefix() );
+    }
+
+    /**
+     * Cookie name prefix : __Secure- when Secure + host-only but path is not '/'
+     */
+    public function test_cookie_name_prefix_secure_when_path_not_root() {
+        $this->add_filter( 'is_ssl', 'yourls_return_true' );
+        $this->add_filter( 'setcookie_domain', function() { return ''; } );
+        $this->add_filter( 'setcookie_path',   function() { return '/sub/'; } );
+        $this->assertSame( '__Secure-', yourls_cookie_name_prefix() );
+    }
+
+    /**
+     * Cookie name : carries the prefix matching the current attributes.
+     * On HTTP, no prefix. On HTTPS, the name is prefixed.
+     */
+    public function test_cookie_name_has_no_prefix_on_http() {
+        $this->add_filter( 'is_ssl', 'yourls_return_false' );
+        $name = yourls_cookie_name();
+        $this->assertStringStartsNotWith( '__Host-',   $name );
+        $this->assertStringStartsNotWith( '__Secure-', $name );
+    }
+
+    public function test_cookie_name_has_host_prefix_on_https_hostonly() {
+        $this->add_filter( 'is_ssl', 'yourls_return_true' );
+        $this->add_filter( 'setcookie_domain', function() { return ''; } );
+        $this->assertStringStartsWith( '__Host-', yourls_cookie_name() );
+    }
+
+    public function test_cookie_name_has_secure_prefix_on_https_with_domain() {
+        $this->add_filter( 'is_ssl', 'yourls_return_true' );
+        $this->add_filter( 'setcookie_domain', function() { return 'sho.rt'; } );
+        $this->assertStringStartsWith( '__Secure-', yourls_cookie_name() );
+    }
+
+    /**
+     * Cookie name : the prefix is the single source of truth shared with the
+     * attributes, so the name actually reflects yourls_cookie_name_prefix().
+     */
+    public function test_cookie_name_matches_prefix() {
+        $this->add_filter( 'is_ssl', 'yourls_return_true' );
+        $this->add_filter( 'setcookie_domain', function() { return ''; } );
+        $this->assertStringStartsWith( yourls_cookie_name_prefix(), yourls_cookie_name() );
     }
 
     /**
@@ -84,4 +278,39 @@ class LoginCookieTest extends PHPUnit\Framework\TestCase {
         $this->assertSame( 0, yourls_did_action('pre_setcookie') );
     }
 
+    /**
+     * Logout request deletes the cookie : yourls_store_cookie('') fires
+     * 'pre_setcookie' with a past expiry time.
+     */
+    public function test_logout_deletes_cookie() {
+        $this->add_action( 'pre_setcookie', function( $args ) {
+            // $args = array($user, $time, $path, $domain, $secure, $httponly)
+            $GLOBALS['__test_logout_cookie_time'] = $args[1];
+        } );
+
+        $before = yourls_did_action( 'pre_setcookie' );
+        yourls_store_cookie( '' );
+        $after = yourls_did_action( 'pre_setcookie' );
+
+        $this->assertSame( $before + 1, $after );
+        // Deleting a cookie uses an expiry time in the past
+        $this->assertLessThan( time(), $GLOBALS['__test_logout_cookie_time'] );
+
+        unset( $GLOBALS['__test_logout_cookie_time'] );
+    }
+
+    /**
+     * Storing a cookie for a real user uses a future expiry time
+     */
+    public function test_store_cookie_uses_future_expiry() {
+        $this->add_action( 'pre_setcookie', function( $args ) {
+            $GLOBALS['__test_store_cookie_time'] = $args[1];
+        } );
+
+        yourls_store_cookie( 'someuser' );
+
+        $this->assertGreaterThan( time(), $GLOBALS['__test_store_cookie_time'] );
+
+        unset( $GLOBALS['__test_store_cookie_time'] );
+    }
 }


### PR DESCRIPTION
Idea surfaced 6 years ago, and [browser support](https://caniuse.com/mdn-http_headers_set-cookie_host_secure_prefixes) is mature now.

Add `__Host-` / `__Secure-` cookie name prefixes to the auth cookie for browser-side hardening on HTTPS installs.

Closes #2785


