### PR TITLE
Return HTTP 409 Conflict (not 400) when a duplicate long URL is rejected

### DIFF
--- a/includes/functions-shorturls.php
+++ b/includes/functions-shorturls.php
@@ -85,7 +85,7 @@ function yourls_add_new_link( $url, $keyword = '', $title = '', $row_id = 1 ) {
             yourls_trim_long_string($url), preg_replace('!https?://!', '',  yourls_get_yourls_site()) . '/'. $url_exists->keyword );
         $return['title']    = $url_exists->title;
         $return['shorturl'] = yourls_link($url_exists->keyword);
-        $return['errorCode'] = $return['statusCode'] = '400'; // 400 Bad Request
+        $return['errorCode'] = $return['statusCode'] = '409'; // 409 Conflict: the URL already exists, and the existing short URL is returned
 
         return yourls_apply_filter( 'add_new_link_already_stored_filter', $return, $url, $keyword, $title );
     }

--- a/tests/tests/shorturl/DuplicateLongURLTest.php
+++ b/tests/tests/shorturl/DuplicateLongURLTest.php
@@ -46,4 +46,30 @@ class DuplicateLongURLTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals( 'success', $newurl['status'] );
     }
 
+    /**
+     * When a duplicate long URL is rejected (unique URLs mode), the API must
+     * return HTTP 409 Conflict -- not 400 Bad Request. The request was well
+     * formed and a usable short URL is returned in the response body, so 400
+     * is misleading and trips HTTP clients that discard the body on 4xx.
+     *
+     * @see https://github.com/YOURLS/YOURLS/issues/3547
+     */
+    public function test_duplicate_long_url_returns_409_conflict() {
+        $url = 'http://' . rand_str(5);
+
+        // First insertion succeeds (baseline "unique URLs" set in setUp)
+        $first = yourls_add_new_link( $url, rand_str(), rand_str() );
+        $this->assertEquals( 'success', $first['status'] );
+
+        // Second insertion of the same long URL is rejected as a conflict
+        $dup = yourls_add_new_link( $url, rand_str(), rand_str() );
+        $this->assertEquals( 'fail', $dup['status'] );
+        $this->assertEquals( 'error:url', $dup['code'] );
+        $this->assertEquals( '409', $dup['statusCode'] );
+        $this->assertEquals( '409', $dup['errorCode'] );
+
+        // The existing short URL is still handed back so callers can use it
+        $this->assertEquals( yourls_link( $first['url']['keyword'] ), $dup['shorturl'] );
+    }
+
 }


### PR DESCRIPTION
## Pre-requisites

- [x] I have read the [Contributing Guidelines](https://github.com/YOURLS/.github/blob/main/CONTRIBUTING.md)
- [x] I am using AI and have read the [AI Policy](https://github.com/YOURLS/.github/blob/main/AI_POLICY.md)

## Change Description

When `YOURLS_UNIQUE_URLS` is enabled and a long URL that already exists is submitted again, the API returns the existing short URL in the body but sets HTTP status 400. Strict HTTP clients such as n8n or curl with `--fail` treat any 4xx as a failure and never read the body, so they cannot reuse the short URL they were just given. That is the problem reported in #3547.

The change is one line: this specific case now returns 409 Conflict instead of 400, which is what @dgw suggested in the issue thread. Genuinely malformed input (`error:nourl`, `error:noloop`) still returns 400. 409 is already a supported status in `yourls_get_HTTP_status()`. A regression test is added to `DuplicateLongURLTest`; it fails on the current code and passes with the change.

AI disclosure, as the policy asks: I used Claude (Anthropic). It investigated the issue, wrote the patch and the test, ran the test suite against MariaDB in Docker, and helped draft this description. I run YOURLS on my own domain and use its API from my own tooling. I have reviewed the change and understand it: one status code constant changes from 400 to 409 in the duplicate URL branch of `yourls_add_new_link()`, plus the test.

Fixes #3547
