### PR TITLE
Make YOURLS_COOKIEKEY unpredictable

### DIFF
--- a/includes/Config/Config.php
+++ b/includes/Config/Config.php
@@ -23,7 +23,7 @@ class Config {
     /**
      * Constants that must be defined in config.php
      */
-    protected const array MANDATORY_CONSTANTS = [
+    protected const MANDATORY_CONSTANTS = [
         'YOURLS_DB_USER',
         'YOURLS_DB_PASS',
         'YOURLS_DB_NAME',
@@ -35,7 +35,7 @@ class Config {
     /**
      * Publicly known values that are not acceptable for YOURLS_COOKIEKEY
      */
-    protected const array INVALID_COOKIEKEYS = [
+    protected const INVALID_COOKIEKEYS = [
         '',
         'modify this text with something random', // default value in config-sample.php
         'qQ4KhL_pu|s@Zm7n#%:b^{A[vhm',            // suggested value in the documentation
@@ -119,12 +119,12 @@ class Config {
      * Check that all mandatory constants are defined
      *
      * @since  1.10.5
-     * @param string[]|null $must_haves Constant names to check, defaults to self::MANDATORY_CONSTANTS
+     * @param string[] $must_haves Constant names to check, defaults to self::MANDATORY_CONSTANTS
      * @return void
      * @throws ConfigException
      */
     public function check_mandatory_constants(array $must_haves = self::MANDATORY_CONSTANTS): void {
-        foreach (($must_haves ?? self::MANDATORY_CONSTANTS) as $must_have) {
+        foreach ($must_haves as $must_have) {
             if (!defined($must_have)) {
                 throw new ConfigException('Config is incomplete (missing at least '.$must_have.') Check config-sample.php and edit your config accordingly');
             }

--- a/includes/Config/Config.php
+++ b/includes/Config/Config.php
@@ -21,6 +21,29 @@ class Config {
     protected string $config;
 
     /**
+     * Constants that must be defined in config.php
+     */
+    protected const array MANDATORY_CONSTANTS = [
+        'YOURLS_DB_USER',
+        'YOURLS_DB_PASS',
+        'YOURLS_DB_NAME',
+        'YOURLS_DB_HOST',
+        'YOURLS_DB_PREFIX',
+        'YOURLS_SITE',
+    ];
+
+    /**
+     * Publicly known values that are not acceptable for YOURLS_COOKIEKEY
+     */
+    protected const array INVALID_COOKIEKEYS = [
+        '',
+        'modify this text with something random', // default value in config-sample.php
+        'qQ4KhL_pu|s@Zm7n#%:b^{A[vhm',            // suggested value in the documentation
+    ];
+
+
+
+    /**
      * @since  1.7.3
      * @param string $config Optional user defined config path
      */
@@ -93,6 +116,36 @@ class Config {
     }
 
     /**
+     * Check that all mandatory constants are defined
+     *
+     * @since  1.10.5
+     * @param string[]|null $must_haves Constant names to check, defaults to self::MANDATORY_CONSTANTS
+     * @return void
+     * @throws ConfigException
+     */
+    public function check_mandatory_constants(array $must_haves = self::MANDATORY_CONSTANTS): void {
+        foreach (($must_haves ?? self::MANDATORY_CONSTANTS) as $must_have) {
+            if (!defined($must_have)) {
+                throw new ConfigException('Config is incomplete (missing at least '.$must_have.') Check config-sample.php and edit your config accordingly');
+            }
+        }
+    }
+
+    /**
+     * Check that the cookie key is defined and is not a publicly known value
+     *
+     * @since  1.10.5
+     * @param mixed $key Cookie key value, or null if the constant is undefined
+     * @return void
+     * @throws ConfigException
+     */
+    public function check_cookie_key(mixed $key): void {
+        if (!is_string($key) || in_array($key, self::INVALID_COOKIEKEYS, true)) {
+            throw new ConfigException('YOURLS_COOKIEKEY is undefined or still set to the sample value. Set it to a long random string, see https://yourls.org/cookiedoc');
+        }
+    }
+
+    /**
      * Define core constants that have not been user defined in config.php
      *
      * @since  1.7.3
@@ -101,18 +154,14 @@ class Config {
      */
     public function define_core_constants(): void {
         // Check minimal config job has been properly done
-        $must_haves = array('YOURLS_DB_USER', 'YOURLS_DB_PASS', 'YOURLS_DB_NAME', 'YOURLS_DB_HOST', 'YOURLS_DB_PREFIX', 'YOURLS_SITE');
-        foreach($must_haves as $must_have) {
-            if (!defined($must_have)) {
-                throw new ConfigException('Config is incomplete (missing at least '.$must_have.') Check config-sample.php and edit your config accordingly');
-            }
-        }
+        $this->check_mandatory_constants();
+        $this->check_cookie_key(defined('YOURLS_COOKIEKEY') ? YOURLS_COOKIEKEY : null);
 
         /**
          * The following has an awful CRAP index and it would be much shorter reduced to something like
          * defining an array of ('YOURLS_SOMETHING' => 'default value') and then a simple loop over the
          * array, checking if $current is defined as a constant and otherwise define said constant with
-         * its default value. I did not wrote it that way because that would make it difficult for code
+         * its default value. I did not write it that way because that would make it difficult for code
          * parsers to identify which constants are defined and where. So, here it is, that long list of
          * if (!defined) define(). Ho and by the way, such beautiful comment, much right aligned, wow !
          */

--- a/includes/functions-auth.php
+++ b/includes/functions-auth.php
@@ -703,7 +703,7 @@ function yourls_tick() {
 }
 
 /**
- * Get the cookie key (secret used for hashing), as maybe defined in config, filtered
+ * Get the cookie key (secret used for hashing), as defined in config, filtered
  *
  * This is the secret key used by yourls_salt() to hash cookies and nonces.
  *
@@ -711,8 +711,7 @@ function yourls_tick() {
  * @return string Cookie key
  */
 function yourls_get_cookie_key(): string {
-    $key = defined('YOURLS_COOKIEKEY') ? YOURLS_COOKIEKEY : hash('sha256', __FILE__);
-    return yourls_apply_filter( 'get_cookie_key', $key );
+    return yourls_apply_filter( 'get_cookie_key', YOURLS_COOKIEKEY );
 }
 
 /**

--- a/tests/data/config/yourls-tests-config-ci.php
+++ b/tests/data/config/yourls-tests-config-ci.php
@@ -12,15 +12,16 @@ define( 'YOURLS_DB_USER', 'root' );
 define( 'YOURLS_DB_PASS', 'secret' );
 define( 'YOURLS_DB_NAME', 'yourls_tests' );
 define( 'YOURLS_DB_HOST', '127.0.0.1:' . getenv('DB_PORT') );
+define( 'YOURLS_DB_PREFIX', 'yourls_' );
 
 /*** Site options */
 define( 'YOURLS_PHP_BIN', 'php' );
 
 /*** Standard YOURLS config. */
 
-define('YOURLS_DB_PREFIX',  'yourls_');
 define('YOURLS_LANG',  'fr_FR'); // locale of a sample translation file in the data dir
 define('YOURLS_DEBUG', true);
+define('YOURLS_COOKIEKEY',  'I &hearts; unit tests');
 
 $yourls_reserved_URL = array(
     'porn', 'sex', 'nigger', 'fuck', 'cunt', 'dick',

--- a/tests/data/config/yourls-tests-config-sample.php
+++ b/tests/data/config/yourls-tests-config-sample.php
@@ -14,15 +14,16 @@ define( 'YOURLS_DB_USER', 'your DB username' );
 define( 'YOURLS_DB_PASS', 'your DB password' );
 define( 'YOURLS_DB_NAME', 'DB name for tests -- an empty one' ); // Must be an EMPTY DATABASE: everything will be erased
 define( 'YOURLS_DB_HOST', 'localhost' );
+define('YOURLS_DB_PREFIX',  'yourls_');
 
 /*** PHP binary - edit if the executable binary is not in system path and put full path ie 'c:/php/php.exe' */
 define( 'YOURLS_PHP_BIN', 'php' );
 
 /*** Most likely, don't edit anything else. Pretty much standard YOURLS config. */
 
-define('YOURLS_DB_PREFIX',  'yourls_');
 define('YOURLS_LANG',  'fr_FR'); // locale of a sample translation file in the data dir
 define('YOURLS_DEBUG', true);
+define('YOURLS_COOKIEKEY',  'I &hearts; unit tests');
 
 $yourls_reserved_URL = array(
     'porn', 'sex', 'nigger', 'fuck', 'cunt', 'dick',

--- a/tests/tests/install/ConfigTest.php
+++ b/tests/tests/install/ConfigTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Checks config check functions
+ */
+#[\PHPUnit\Framework\Attributes\Group('install')]
+class ConfigTest extends PHPUnit\Framework\TestCase {
+
+    /**
+     * Test (sort of) defining constants
+     */
+    public function test_correct_config() {
+        $test = new \YOURLS\Config\Config(YOURLS_CONFIGFILE);
+
+        // This should return a readable file
+        $readable = is_readable($test->find_config());
+        $this->assertTrue($readable);
+        // For the record, $this->assertFileIsReadable() was introduced around PHPUnit 5.6
+
+        // redefining YOURLS_ constants should not throw any error ("constant already defined...")
+        // or define any new constants
+        $consts = get_defined_constants(true);
+        $before = $consts['user'];
+        $test->define_core_constants();
+        $consts = get_defined_constants(true);
+        $after = $consts['user'];
+        $this->assertSame($before,$after);
+    }
+
+    /**
+     * Test incorrect config provided
+     */
+    public function test_incorrect_config() {
+        $this->expectException(YOURLS\Exceptions\ConfigException::class);
+        $this->expectExceptionMessageMatches('/User defined config not found at \'[0-9a-z]+\'/');
+
+        $test = new \YOURLS\Config\Config(rand_str());
+        $test->find_config();
+    }
+
+    /**
+     * Test config not found
+     */
+    public function test_not_found_config() {
+        $this->expectException(YOURLS\Exceptions\ConfigException::class);
+        $this->expectExceptionMessage('Cannot find config.php. Please read the readme.html to learn how to install YOURLS');
+
+        $test = new \YOURLS\Config\Config();
+        $test->set_root(rand_str());
+        $test->find_config();
+    }
+
+    /**
+     * Missing constant triggers an exception naming it
+     */
+    public function test_missing_mandatory_constant() {
+        $this->expectException(YOURLS\Exceptions\ConfigException::class);
+        $this->expectExceptionMessageMatches('/YOURLS_NOT_DEFINED_1337/');
+        new \YOURLS\Config\Config()->check_mandatory_constants(['YOURLS_DB_USER', 'YOURLS_NOT_DEFINED_1337']);
+    }
+
+    /**
+     * Defined constants pass the check
+     */
+    public function test_defined_mandatory_constants() {
+        $this->expectNotToPerformAssertions();
+        new \YOURLS\Config\Config()->check_mandatory_constants(['YOURLS_DB_USER', 'YOURLS_SITE']);
+    }
+
+    /**
+     * Unacceptable cookie key values
+     *
+     * @return array
+     */
+    public static function bad_cookie_keys(): array {
+        return [
+            'undefined'  => [null],
+            'empty'      => [''],
+            'sample'     => ['modify this text with something random'],
+            'doc'        => ['qQ4KhL_pu|s@Zm7n#%:b^{A[vhm'],
+            'not string' => [1337],
+        ];
+    }
+
+    /**
+     * @param mixed $key
+     * @return void
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('bad_cookie_keys')]
+    public function test_bad_cookie_key(mixed $key): void {
+        $this->expectException(YOURLS\Exceptions\ConfigException::class);
+        new \YOURLS\Config\Config()->check_cookie_key($key);
+    }
+
+    /**
+     * A random long string is a valid cookie key
+     */
+    public function test_good_cookie_key() {
+        $this->expectNotToPerformAssertions();
+        new \YOURLS\Config\Config()->check_cookie_key(bin2hex(random_bytes(16)));
+    }
+
+    /**
+     * Test Init actions. Not sure this is a good idea, might become cumbersome to maintain?
+     */
+    public function test_init_defaults() {
+        $test = new \YOURLS\Config\InitDefaults();
+
+        $expected = array (
+            'include_core_funcs' => true,
+            'default_timezone' => true,
+            'load_default_textdomain' => true,
+            'check_maintenance_mode' => true,
+            'fix_request_uri' => true,
+            'redirect_ssl' => true,
+            'include_db' => true,
+            'include_cache' => true,
+            'return_if_fast_init' => true,
+            'get_all_options' => true,
+            'register_shutdown' => true,
+            'core_loaded' => true,
+            'redirect_to_install' => true,
+            'check_if_upgrade_needed' => true,
+            'load_plugins' => true,
+            'plugins_loaded_action' => true,
+            'check_new_version' => true,
+            'init_admin' => true,
+        );
+
+        $actual = get_class_vars(get_class($test));
+
+        $this->assertSame($expected, $actual);
+    }
+
+}

--- a/tests/tests/install/ConfigTest.php
+++ b/tests/tests/install/ConfigTest.php
@@ -56,7 +56,7 @@ class ConfigTest extends PHPUnit\Framework\TestCase {
     public function test_missing_mandatory_constant() {
         $this->expectException(YOURLS\Exceptions\ConfigException::class);
         $this->expectExceptionMessageMatches('/YOURLS_NOT_DEFINED_1337/');
-        new \YOURLS\Config\Config()->check_mandatory_constants(['YOURLS_DB_USER', 'YOURLS_NOT_DEFINED_1337']);
+        (new \YOURLS\Config\Config())->check_mandatory_constants(['YOURLS_DB_USER', 'YOURLS_NOT_DEFINED_1337']);
     }
 
     /**
@@ -64,7 +64,7 @@ class ConfigTest extends PHPUnit\Framework\TestCase {
      */
     public function test_defined_mandatory_constants() {
         $this->expectNotToPerformAssertions();
-        new \YOURLS\Config\Config()->check_mandatory_constants(['YOURLS_DB_USER', 'YOURLS_SITE']);
+        (new \YOURLS\Config\Config())->check_mandatory_constants(['YOURLS_DB_USER', 'YOURLS_SITE']);
     }
 
     /**
@@ -89,7 +89,7 @@ class ConfigTest extends PHPUnit\Framework\TestCase {
     #[\PHPUnit\Framework\Attributes\DataProvider('bad_cookie_keys')]
     public function test_bad_cookie_key(mixed $key): void {
         $this->expectException(YOURLS\Exceptions\ConfigException::class);
-        new \YOURLS\Config\Config()->check_cookie_key($key);
+        (new \YOURLS\Config\Config())->check_cookie_key($key);
     }
 
     /**
@@ -97,7 +97,7 @@ class ConfigTest extends PHPUnit\Framework\TestCase {
      */
     public function test_good_cookie_key() {
         $this->expectNotToPerformAssertions();
-        new \YOURLS\Config\Config()->check_cookie_key(bin2hex(random_bytes(16)));
+        (new \YOURLS\Config\Config())->check_cookie_key(bin2hex(random_bytes(16)));
     }
 
     /**

--- a/tests/tests/install/InstallTest.php
+++ b/tests/tests/install/InstallTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Checks install misc functions
+ * Checks install DB functions
  */
 #[\PHPUnit\Framework\Attributes\Group('install')]
 class InstallTest extends PHPUnit\Framework\TestCase {
@@ -61,82 +61,6 @@ class InstallTest extends PHPUnit\Framework\TestCase {
         );
 
         $this->assertSame( $expected, yourls_create_sql_tables() );
-    }
-
-    /**
-     * Test (sort of) defining constants
-     */
-    public function test_correct_config() {
-        $test = new \YOURLS\Config\Config(YOURLS_CONFIGFILE);
-
-        // This should return a readable file
-        $readable = is_readable($test->find_config(YOURLS_CONFIGFILE));
-        $this->assertTrue($readable);
-        // For the record, $this->assertFileIsReadable() was introduced around PHPUnit 5.6
-
-        // redefining YOURLS_ constants should not throw any error ("constant already defined...")
-        // or define any new constants
-        $consts = get_defined_constants(true);
-        $before = $consts['user'];
-        $test->define_core_constants();
-        $consts = get_defined_constants(true);
-        $after = $consts['user'];
-        $this->assertSame($before,$after);
-    }
-
-    /**
-     * Test incorrect config provided
-     */
-    public function test_incorrect_config() {
-        $this->expectException(YOURLS\Exceptions\ConfigException::class);
-        $this->expectExceptionMessageMatches('/User defined config not found at \'[0-9a-z]+\'/');
-
-        $test = new \YOURLS\Config\Config(rand_str());
-        $test->find_config();
-    }
-
-    /**
-     * Test config not found
-     */
-    public function test_not_found_config() {
-        $this->expectException(YOURLS\Exceptions\ConfigException::class);
-        $this->expectExceptionMessage('Cannot find config.php. Please read the readme.html to learn how to install YOURLS');
-
-        $test = new \YOURLS\Config\Config();
-        $test->set_root(rand_str());
-        $test->find_config();
-    }
-
-    /**
-     * Test Init actions. Not sure this is a good idea, might become cumbersome to maintain?
-     */
-    public function test_init_defaults() {
-        $test = new \YOURLS\Config\InitDefaults();
-
-        $expected = array (
-            'include_core_funcs' => true,
-            'default_timezone' => true,
-            'load_default_textdomain' => true,
-            'check_maintenance_mode' => true,
-            'fix_request_uri' => true,
-            'redirect_ssl' => true,
-            'include_db' => true,
-            'include_cache' => true,
-            'return_if_fast_init' => true,
-            'get_all_options' => true,
-            'register_shutdown' => true,
-            'core_loaded' => true,
-            'redirect_to_install' => true,
-            'check_if_upgrade_needed' => true,
-            'load_plugins' => true,
-            'plugins_loaded_action' => true,
-            'check_new_version' => true,
-            'init_admin' => true,
-        );
-
-        $actual = get_class_vars(get_class($test));
-
-        $this->assertSame($expected, $actual);
     }
 
 }


### PR DESCRIPTION
Till this, missing `YOURLS_COOKIEKEY` falls back to a potentially predictable auth-cookie key, allowing unauthorized login.

New logic : if `YOURLS_COOKIEKEY` isn't defined, or is a publicly known value, die.