### PR TITLE
Fix content-type edge cases when fetching titles

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1024,8 +1024,8 @@ function yourls_get_remote_title(string $url ): string {
         return $url;
     }
 
-    // look for <title>. No title found? Return the URL
-    if ( preg_match( '/<title>(.*?)<\/title>/is', $content, $found ) ) {
+    // look for <title>, which can have attributes. No title found? Return the URL
+    if ( preg_match( '/<title(?:\s[^>]*)?>(.*?)<\/title>/is', $content, $found ) ) {
         $title = $found[ 1 ];
         unset( $found );
     }
@@ -1038,17 +1038,34 @@ function yourls_get_remote_title(string $url ): string {
     // Get charset as (and if) defined by the HTML meta tag. We should match
     // <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     // or <meta charset='utf-8'> and all possible variations: see https://gist.github.com/ozh/7951236
-    if ( preg_match( '/<meta[^>]*charset\s*=["\' ]*([a-zA-Z0-9\-_]+)/is', $content, $found ) ) {
-        if ( yourls_is_valid_charset( $found[ 1 ] ) ) {
-            $charset = $found[ 1 ];
+    // A 'charset=' string can also appear where it does not declare anything, for instance in the
+    // description of the page, so check each <meta> tag and to find if a charset is declared.
+    if ( preg_match_all( '/<meta\s[^>]*>/is', $content, $metas ) ) {
+        foreach ( $metas[ 0 ] as $meta ) {
+            if ( preg_match( '/\bcontent\s*=\s*["\']?[^"\']*?charset\s*=["\' ]*([a-zA-Z0-9\-_]+)/is', $meta, $found ) ) {
+                // A charset in the 'content' attribute only counts in a Content-Type declaration
+                if ( !preg_match( '/\bhttp-equiv\s*=\s*["\']?content-type/is', $meta ) ) {
+                    unset( $found );
+                    continue;
+                }
+            }
+            elseif ( !preg_match( '/\bcharset\s*=["\' ]*([a-zA-Z0-9\-_]+)/is', $meta, $found ) ) {
+                continue;
+            }
+            // First declaration wins, whether it is valid or not
+            if ( yourls_is_valid_charset( $found[ 1 ] ) ) {
+                $charset = $found[ 1 ];
+            }
+            unset( $found );
+            break;
         }
-        unset( $found );
     }
     if ( empty( $charset ) ) {
         // No charset found in HTML. Get charset as (and if) defined by the server response
-        $_charset = current( $response->headers->getValues( 'content-type' ) );
+        $_charset = current( (array)$response->headers->getValues( 'content-type' ) );
+        // The charset value can be a quoted string: 'text/html; charset="utf-8"'
         if ( preg_match( '/charset=(\S+)/', $_charset, $found ) ) {
-            $_charset = trim( $found[ 1 ], ';' );
+            $_charset = trim( $found[ 1 ], ';"\'' );
             if ( yourls_is_valid_charset( $_charset ) ) {
                 $charset = $_charset;
             }
@@ -1056,13 +1073,14 @@ function yourls_get_remote_title(string $url ): string {
         }
     }
 
-    // Conversion to utf-8 if what we have is not utf8 already
-    if ( strtolower( $charset ) != 'utf-8' && function_exists( 'mb_convert_encoding' ) ) {
+    // Conversion to utf-8 if what we have is not utf8 already. A page can also declare utf-8 and
+    // still serve invalid utf-8, so in that case convert too, to replace the invalid characters.
+    if ( function_exists( 'mb_convert_encoding' ) ) {
         // We use @ to remove warnings because mb_ functions are easily bitching about illegal chars
-        if ( $charset ) {
+        if ( $charset && strtolower( $charset ) != 'utf-8' ) {
             $title = @mb_convert_encoding( $title, 'UTF-8', $charset );
         }
-        else {
+        elseif ( !mb_check_encoding( $title, 'UTF-8' ) ) {
             $title = @mb_convert_encoding( $title, 'UTF-8' );
         }
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1076,12 +1076,11 @@ function yourls_get_remote_title(string $url ): string {
     // Conversion to utf-8 if what we have is not utf8 already. A page can also declare utf-8 and
     // still serve invalid utf-8, so in that case convert too, to replace the invalid characters.
     if ( function_exists( 'mb_convert_encoding' ) ) {
-        // We use @ to remove warnings because mb_ functions are easily bitching about illegal chars
         if ( $charset && strtolower( $charset ) != 'utf-8' ) {
-            $title = @mb_convert_encoding( $title, 'UTF-8', $charset );
+            $title = mb_convert_encoding( $title, 'UTF-8', $charset );
         }
         elseif ( !mb_check_encoding( $title, 'UTF-8' ) ) {
-            $title = @mb_convert_encoding( $title, 'UTF-8' );
+            $title = mb_convert_encoding( $title, 'UTF-8' );
         }
     }
 

--- a/tests/data/remote-pages/charset-header-only.html
+++ b/tests/data/remote-pages/charset-header-only.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html><html lang="en"><head>
+    <title>Café Central</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/data/remote-pages/lying-charset.html
+++ b/tests/data/remote-pages/lying-charset.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><html lang="en"><head>
+    <meta charset="utf-8">
+    <title>Café Central</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/data/remote-pages/meta-charset-decoy.html
+++ b/tests/data/remote-pages/meta-charset-decoy.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html><html lang="en"><head>
+    <meta name="description" content="Everything you always wanted to know about charset=iso-8859-1 and other encodings">
+    <meta charset="utf-8">
+    <title>Café Central</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/data/remote-pages/title-with-attributes.html
+++ b/tests/data/remote-pages/title-with-attributes.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><html lang="en"><head>
+    <meta charset="utf-8">
+    <title stuff=something thing="something">Attributes In The Title Tag</title>
+</head>
+<body>
+
+<p>Yay !</p>
+
+</body>
+</html>

--- a/tests/tests/format/RemoteTitleTest.php
+++ b/tests/tests/format/RemoteTitleTest.php
@@ -77,4 +77,46 @@ class RemoteTitleTest extends PHPUnit\Framework\TestCase {
         $this->assertSame( $expected, yourls_get_remote_title( 'https://example.com/mbconvert1.html?charset=invalid' ) );
     }
 
+    /**
+     * The <title> tag can have attributes
+     *
+     * <title class="foo" id="bar">Attributes In The Title Tag</title>
+     */
+    function test_title_tag_with_attributes() {
+        $expected = 'Attributes In The Title Tag';
+        $this->assertSame( $expected, yourls_get_remote_title( 'https://example.com/title-with-attributes.html' ) );
+    }
+
+    /**
+     * Charset in the Content-Type response header can be quoted
+     *
+     * Both charset=ISO-8859-1 and 'charset="ISO-8859-1"' are valid.
+     * The page has no <meta charset> : the query string passed to the mockup HTTP request handler simulates the header.
+     */
+    function test_quoted_charset_in_content_type_header() {
+        $expected = 'Café Central';
+        // Same charset, quoted and unquoted
+        $this->assertSame( $expected, yourls_get_remote_title( 'https://example.com/charset-header-only.html?charset=ISO-8859-1' ) );
+        $this->assertSame( $expected, yourls_get_remote_title( 'https://example.com/charset-header-only.html?charset=%22ISO-8859-1%22' ) );
+    }
+
+    /**
+     * A 'charset=' string in another meta tag is not a charset declaration
+     *
+     * The page declares utf-8, but an earlier <meta name="description"> mentions 'charset=iso-8859-1'
+     * in its content attribute.
+     */
+    function test_meta_charset_decoy() {
+        $expected = 'Café Central';
+        $this->assertSame( $expected, yourls_get_remote_title( 'https://example.com/meta-charset-decoy.html' ) );
+    }
+
+    /**
+     * Fetched titles must be valid UTF-8, even when the page lies about its charset. H�h� !
+     */
+    function test_title_is_valid_utf8_when_page_lies_about_its_charset() {
+        $title = yourls_get_remote_title( 'https://example.com/lying-charset.html' );
+        $this->assertTrue( mb_check_encoding( $title, 'UTF-8' ), 'Title is not valid UTF-8: ' . bin2hex( $title ) );
+    }
+
 }


### PR DESCRIPTION
Issue #4143 raised the case where a server would serve page without a content-type - easy fix with a simple `(array)` casting. While I was at it, I digged and found a few other edge cases where our remote title fetching would fail - all now covered in new unit tests.