### PR TITLE
feat: dark mode for the admin interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ user/*
 !user/plugins/sample-page/
 !user/plugins/sample-plugin/
 !user/plugins/sample-toolbar/
+!user/plugins/dark-mode/
 # ... example pages
 !user/pages/examplepage.php
 # ... and index.html files

--- a/user/plugins/dark-mode/dark.css
+++ b/user/plugins/dark-mode/dark.css
@@ -1,0 +1,293 @@
+/* Dark theme for the YOURLS admin interface.
+ *
+ * One palette, declared once as custom properties; every rule below reads from
+ * it. Wrapped in prefers-color-scheme so it follows the OS setting. To add an
+ * explicit toggle later, repeat the selectors as html[data-theme="dark"] and
+ * move the rules out of the media query.
+ */
+@media (prefers-color-scheme: dark) {
+
+:root {
+    --dm-bg:          #12161b;
+    --dm-surface:     #1b2027;
+    --dm-surface-2:   #232a33;
+    --dm-surface-3:   #2c343f;
+    --dm-text:        #c9d1d9;
+    --dm-text-dim:    #8b949e;
+    --dm-accent:      #58a6d8;
+    --dm-accent-dim:  #2a6f96;
+    --dm-border:      #30363d;
+    --dm-error-bg:    #3a1d1d;
+    --dm-error-fg:    #ff7b72;
+    --dm-warning-bg:  #3a2f14;
+    --dm-warning-fg:  #e3b341;
+    --dm-success-bg:  #14301c;
+    --dm-success-fg:  #7ee787;
+    --dm-mark-bg:     #443a12;
+    --dm-mark-fg:     #f0e6a8;
+    color-scheme: dark;
+}
+
+/* --- Page frame ------------------------------------------------------- */
+body {
+    background: var(--dm-bg);
+    color: var(--dm-text);
+}
+#wrap {
+    background: var(--dm-surface);
+    border-color: var(--dm-accent-dim);
+}
+a, a:link, a:active, a:visited,
+h1 a, h1 a:link, h1 a:active, h1 a:visited {
+    color: var(--dm-accent);
+}
+h1 a:hover span {
+    color: #8ecbef;
+}
+ul#admin_menu li {
+    color: var(--dm-text-dim);
+}
+ul#admin_menu li:hover {
+    color: var(--dm-text);
+}
+#footer p {
+    background: var(--dm-surface);
+    border-color: var(--dm-accent-dim);
+}
+#footer p a {
+    background-color: transparent;
+}
+.notice {
+    background: var(--dm-surface-2);
+    border-color: var(--dm-accent-dim);
+}
+
+/* --- Type accents ----------------------------------------------------- */
+code {
+    background: var(--dm-surface-2);
+}
+tt, .sub_wrap span {
+    background: var(--dm-mark-bg);
+    color: var(--dm-mark-fg);
+}
+td.url small a {
+    color: var(--dm-text-dim);
+}
+
+/* --- Forms and buttons ------------------------------------------------ */
+input.text, select, textarea,
+input.button, td.actions .button {
+    color: var(--dm-text);
+    background-color: var(--dm-surface-2);
+    border-color: var(--dm-accent-dim);
+}
+input.primary {
+    background: var(--dm-surface-3);
+    border-color: var(--dm-accent);
+}
+input.text:focus, textarea:focus {
+    border-color: var(--dm-accent);
+}
+td.actions .button:active {
+    border-color: var(--dm-accent);
+}
+td.actions .button.disabled, #add-button.disabled {
+    background: var(--dm-surface-3);
+    border-color: var(--dm-border);
+}
+td.actions .button.loading, #add-button.loading {
+    background-color: var(--dm-surface-3);
+    color: var(--dm-surface-3);
+}
+a.bookmarklet {
+    background-color: var(--dm-surface-2);
+    border-color: var(--dm-accent-dim);
+}
+
+/* --- Add-a-link box --------------------------------------------------- */
+#new_url {
+    background: var(--dm-surface);
+    border-color: var(--dm-border);
+}
+#new_url div {
+    background: var(--dm-surface-3);
+}
+#new_url #feedback {
+    background: var(--dm-mark-bg);
+    color: var(--dm-mark-fg);
+    border-color: var(--dm-mark-bg);
+}
+#new_url #feedback .fail {
+    color: var(--dm-error-fg);
+}
+tr.edit-row td {
+    /* core sets this one with !important */
+    background: var(--dm-surface-3) !important;
+}
+
+/* --- Status colours: these carry meaning, so keep them distinguishable - */
+.error {
+    color: var(--dm-error-fg);
+    background: var(--dm-error-bg);
+}
+.warning {
+    color: var(--dm-warning-fg);
+    background: var(--dm-warning-bg);
+}
+.success {
+    color: var(--dm-success-fg);
+    background: var(--dm-success-bg);
+}
+.jquery-notify-bar {
+    background-color: var(--dm-surface-2);
+    color: var(--dm-text);
+    border-bottom-color: var(--dm-border);
+}
+.jquery-notify-bar.error, .jquery-notify-bar.fail {
+    color: var(--dm-error-fg);
+    background-color: var(--dm-error-bg);
+}
+.jquery-notify-bar.success {
+    color: var(--dm-success-fg);
+    background-color: var(--dm-success-bg);
+}
+
+/* --- Delete confirmation dialog --------------------------------------- */
+#delete-confirm-dialog {
+    background-color: var(--dm-surface);
+    color: var(--dm-text);
+    border-color: var(--dm-accent-dim);
+}
+#delete-confirm-dialog > div[name="dialog_title"] {
+    background-color: var(--dm-surface-3);
+    color: var(--dm-accent);
+}
+#delete-confirm-dialog div.confirm-message {
+    background-color: var(--dm-surface);
+}
+#delete-confirm-dialog div.confirm-message ul {
+    border-left-color: var(--dm-accent);
+}
+#delete-confirm-dialog div.confirm-message ul li span {
+    border-color: var(--dm-accent-dim);
+    color: var(--dm-text);
+}
+#delete-confirm-dialog div.button-group {
+    background-color: var(--dm-surface-2);
+}
+#delete-confirm-dialog::backdrop {
+    background-color: #000;
+}
+
+/* --- Sortable tables -------------------------------------------------- */
+table.tblSorter {
+    background-color: var(--dm-border);
+}
+table.tblSorter thead tr th,
+table.tblSorter tfoot tr th,
+table.tblSorter th.header {
+    background-color: var(--dm-surface-3);
+    color: var(--dm-text);
+    border-color: var(--dm-surface);
+}
+table.tblSorter tfoot tr,
+table.tblSorter tfoot tr th {
+    background-color: var(--dm-surface-2);
+}
+table.tblSorter thead tr .tablesorter-headerAsc,
+table.tblSorter thead tr .tablesorter-headerDesc {
+    background-color: var(--dm-accent-dim);
+}
+table.tblSorter tbody td {
+    background-color: var(--dm-surface);
+    color: var(--dm-text);
+}
+table.tblSorter tbody tr.normal-row td {
+    background: var(--dm-surface-2);
+}
+table.tblSorter tbody tr.normal-row:hover td,
+table.tblSorter tbody tr.alt-row:hover td {
+    background-color: var(--dm-surface-3);
+}
+.navigation .nav_link a, .navigation .nav_current {
+    background: var(--dm-surface-2);
+    border-color: var(--dm-border);
+}
+.navigation .nav_current {
+    background: none;
+}
+.navigation .nav_link a:hover {
+    background: var(--dm-accent-dim);
+    border-color: var(--dm-accent-dim);
+}
+
+/* --- Stats pages ------------------------------------------------------ */
+ul.toggle_display,
+#tabs ul#headers {
+    border-bottom-color: var(--dm-border);
+}
+#tabs ul#headers li a,
+#stats_lines li a {
+    color: var(--dm-text);
+    background: var(--dm-surface-2);
+    border-color: var(--dm-border);
+}
+#tabs ul#headers li a:hover,
+#stats_lines li a:hover {
+    background: var(--dm-surface-3);
+}
+#tabs ul#headers li a.selected,
+#tabs ul#headers li a.selected:hover,
+#stats_lines li a.selected,
+#stats_lines li a.selected:hover {
+    background: var(--dm-surface);
+    border-color: var(--dm-border);
+    border-bottom-color: var(--dm-surface);
+}
+/* js/infos.js stripes these rows with an inline background */
+#historical_clicks li:nth-child(odd) {
+    background: var(--dm-surface-2) !important;
+}
+#historical_clicks li:hover {
+    background: var(--dm-surface-3) !important;
+}
+/* Google charts draw inline SVG: the plugin makes the chart background
+ * transparent server-side, the labels are recoloured here. */
+div[id^="visualization_"] svg text {
+    fill: var(--dm-text);
+}
+
+/* --- Date picker ------------------------------------------------------ */
+.datepicker {
+    border-color: var(--dm-border);
+}
+.datepicker th, .datepicker tfoot td {
+    background: var(--dm-surface-3);
+    color: var(--dm-text);
+}
+.datepicker tbody td {
+    background: var(--dm-surface);
+    border-color: var(--dm-border);
+    color: var(--dm-text);
+}
+.datepicker tbody td.date.over {
+    background-color: var(--dm-accent-dim);
+}
+.datepicker tbody td.date.chosen {
+    background-color: var(--dm-success-bg);
+    color: var(--dm-success-fg);
+}
+
+/* --- Share box -------------------------------------------------------- */
+div.share {
+    background: var(--dm-surface-2);
+    border-color: var(--dm-accent-dim);
+}
+#charcount {
+    color: var(--dm-text-dim);
+}
+#charcount.negative {
+    color: var(--dm-error-fg);
+}
+
+}

--- a/user/plugins/dark-mode/plugin.php
+++ b/user/plugins/dark-mode/plugin.php
@@ -1,0 +1,37 @@
+<?php
+/*
+Plugin Name: Dark Mode
+Plugin URI: https://github.com/YOURLS/YOURLS
+Description: Dark theme for the admin interface, following the OS setting via <code>prefers-color-scheme</code>.
+Version: 1.0
+Author: YOURLS
+Author URI: https://yourls.org/
+*/
+
+// No direct call
+if( !defined( 'YOURLS_ABSPATH' ) ) die();
+
+/**
+ * Load the dark theme stylesheet.
+ *
+ * 'html_head' fires after all the core stylesheets, so these rules win at equal
+ * specificity without !important (except where core JS writes inline styles).
+ */
+yourls_add_action( 'html_head', 'darkmode_add_css' );
+function darkmode_add_css() {
+    $url = yourls_plugin_url( __DIR__ ) . '/dark.css';
+    echo '<link rel="stylesheet" href="' . yourls_esc_url( $url ) . '?v=1.0" type="text/css" media="screen" />' . "\n";
+}
+
+/**
+ * Make the Google charts on the stats pages blend into whichever theme is
+ * active. The colour scheme is a client-side setting, so the chart background
+ * is made transparent here and the labels are recoloured in dark.css.
+ */
+foreach ( array( 'stats_line_options', 'stats_pie_options', 'stats_countries_map_options' ) as $darkmode_filter ) {
+    yourls_add_filter( $darkmode_filter, 'darkmode_chart_options' );
+}
+function darkmode_chart_options( $options ) {
+    $options['backgroundColor'] = 'transparent'; // yourls_google_viz_code() adds the JS quotes
+    return $options;
+}


### PR DESCRIPTION
## Dark mode for the admin interface

Adds a self-contained plugin, `user/plugins/dark-mode/`, that gives the admin
area a dark theme. No core file is modified — the theme is pure override, so it
can be switched off by deactivating the plugin.

### How it works

- `plugin.php` hooks `html_head` to load `dark.css`. That action fires after
  every core stylesheet, so the overrides win at equal specificity without
  needing `!important`.
- `dark.css` declares one palette as CSS custom properties on `:root` and
  derives every rule from it, all inside `@media (prefers-color-scheme: dark)`,
  so the theme follows the OS setting and the light theme is untouched. A
  comment at the top of the file marks where an explicit toggle would hook in
  if one is wanted later.
- The plugin also filters `stats_line_options`, `stats_pie_options` and
  `stats_countries_map_options` to set the Google chart background to
  `transparent`, so the charts sit on either theme; the chart labels are
  recoloured in CSS.
- `.gitignore` gains `!user/plugins/dark-mode/` alongside the existing plugin
  exceptions.

### Coverage

Surfaces from `style.css`, `infos.css`, `cal.css`, `share.css` and
`tablesorter.css`: page frame and menu, forms and action buttons, the add-URL
box, the delete confirmation dialog, the notify bar, sortable tables and
pagination, the stats tabs and historical clicks list, the date picker, and the
share box.

Colours that carry meaning rather than decoration were kept distinguishable
instead of being inverted: the error, warning and success states each keep
their own hue against the dark background. The historical clicks rows need
`!important` because `js/infos.js` writes their striping as an inline style.

### How to test

Activate **Dark Mode** from Manage Plugins, then switch the OS colour scheme
and compare the admin index, a stats page, the tools page and the plugins page
in both schemes. With the OS in light mode nothing should change at all.

Feedback on the palette is welcome — the values are all in the `:root` block at
the top of `dark.css`, so they are easy to adjust in one place.

---

- [x] I have read the Contributing Guidelines
- [x] I am using AI and have read the AI Policy
